### PR TITLE
Organize into multiple files

### DIFF
--- a/ltiauthenticator/__init__.py
+++ b/ltiauthenticator/__init__.py
@@ -1,0 +1,2 @@
+from .auth import LTIAuthenticator
+from .validator import LTILaunchValidator, LTILaunchValidationError

--- a/ltiauthenticator/auth.py
+++ b/ltiauthenticator/auth.py
@@ -1,0 +1,77 @@
+from traitlets import Bool, Dict
+from tornado import gen, web
+
+from jupyterhub.auth import Authenticator
+from jupyterhub.handlers import BaseHandler
+from jupyterhub.utils import url_path_join
+
+from .validator import LTILaunchValidator, LTILaunchValidationError
+
+class LTIAuthenticator(Authenticator):
+    """
+    JupyterHub Authenticator for use with LTI based services (EdX, Canvas, etc)
+    """
+
+    auto_login = True
+    login_service = 'LTI'
+
+    consumers = Dict(
+        {},
+        config=True,
+        help="""
+        A dict of consumer keys mapped to consumer secrets for those keys.
+
+        Allows multiple consumers to securely send users to this JupyterHub
+        instance.
+        """
+    )
+
+    def get_handlers(self, app):
+        return [
+            ('/lti/launch', LTIAuthenticateHandler)
+        ]
+
+
+    @gen.coroutine
+    def authenticate(self, handler, data=None):
+        # FIXME: Run a process that cleans up old nonces every other minute
+        validator = LTILaunchValidator(self.consumers)
+
+        args = {}
+        for k, values in handler.request.body_arguments.items():
+            args[k] = values[0].decode() if len(values) == 1 else [v.decode() for v in values]
+
+
+        try:
+            if validator.validate_launch_request(
+                    handler.request.full_url(),
+                    handler.request.headers,
+                    args
+            ):
+                return {
+                    'name': handler.get_body_argument('user_id'),
+                    'auth_state': {k: v for k, v in args.items() if not k.startswith('oauth_')}
+                }
+        except LTILaunchValidationError as e:
+            raise web.HTTPError(401, e.message)
+
+
+    def login_url(self, base_url):
+        return url_path_join(base_url, '/lti/launch')
+
+
+class LTIAuthenticateHandler(BaseHandler):
+    """
+    Handler for /lti/launch
+
+    Implements v1 of the LTI protocol for passing authentication information
+    through.
+
+    If there's a custom parameter called 'next', will redirect user to
+    that URL after authentication. Else, will send them to /home.
+    """
+
+    @gen.coroutine
+    def post(self):
+        user = yield self.login_user()
+        self.redirect(self.get_body_argument('custom_next', self.get_next_url()))

--- a/tests/test_lti.py
+++ b/tests/test_lti.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from tornado import web
-from ltiauthenticator import LTILaunchValidator
+from ltiauthenticator import LTILaunchValidator, LTILaunchValidationError
 from oauthlib.oauth1.rfc5849 import signature
 
 def make_args(
@@ -66,7 +66,7 @@ def test_wrong_key():
 
     validator = LTILaunchValidator({'wrongkey': consumer_secret})
 
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(LTILaunchValidationError):
         assert validator.validate_launch_request(launch_url, headers, args)
 
 def test_wrong_secret():
@@ -87,7 +87,7 @@ def test_wrong_secret():
 
     validator = LTILaunchValidator({consumer_key: 'wrongsecret'})
 
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(LTILaunchValidationError):
         validator.validate_launch_request(launch_url, headers, args)
 
 def test_full_replay():
@@ -110,7 +110,7 @@ def test_full_replay():
 
     assert validator.validate_launch_request(launch_url, headers, args)
 
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(LTILaunchValidationError):
         validator.validate_launch_request(launch_url, headers, args)
 
 def test_partial_replay_timestamp():
@@ -134,7 +134,7 @@ def test_partial_replay_timestamp():
     assert validator.validate_launch_request(launch_url, headers, args)
 
     args['oauth_timestamp'] = str(int(float(args['oauth_timestamp'])) - 1)
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(LTILaunchValidationError):
         validator.validate_launch_request(launch_url, headers, args)
 
 def test_partial_replay_nonce():
@@ -158,7 +158,7 @@ def test_partial_replay_nonce():
     assert validator.validate_launch_request(launch_url, headers, args)
 
     args['oauth_nonce'] = args['oauth_nonce'] + "1"
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(LTILaunchValidationError):
         validator.validate_launch_request(launch_url, headers, args)
 
 def test_dubious_extra_args():
@@ -182,5 +182,5 @@ def test_dubious_extra_args():
     assert validator.validate_launch_request(launch_url, headers, args)
 
     args['extra_credential'] = 'i have admin powers'
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(LTILaunchValidationError):
         validator.validate_launch_request(launch_url, headers, args)


### PR DESCRIPTION
- Allow LTILaunchValidator to be used without needing to use all
  the JupyterHub related things!
- Use a specific LTLaunchValidationError than just web.HTTPError