### PR TITLE
Canvas Implementation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Moodle, Blackboard, etc.
 So far, `ltiauthenticator` has been tested with [EdX](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html) and [Canvas](https://canvas.instructure.com/doc/api/file.tools_intro.html). Documentation contributions are highly welcome!
 
 Note that with this authenticator, going directly to the hub url will no longer
-allow you to log in. You *must* visit the hub through an appropriate Tool
+allow you to log in. You _must_ visit the hub through an appropriate Tool
 Consumer (such as EdX) to be able to log in.
 
 ## Installation
@@ -28,94 +28,97 @@ _A note about LTI Passports: These can essentially be any 3 strings put together
 
 ### EdX
 
-1. You need access to [EdX Studio](https://studio.edx.org/) to set up LTI. You
-   might have to contact your EdX Liaison to get access.
+1.  You need access to [EdX Studio](https://studio.edx.org/) to set up LTI. You
+    might have to contact your EdX Liaison to get access.
 
-2. [Enable LTI Components](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#enabling-lti-components-for-a-course) 
-   for your course.
+2.  [Enable LTI Components](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#enabling-lti-components-for-a-course)
+    for your course.
 
-3. Create an *client key* for use by EdX against your hub. You can do so by
-   running `openssl rand -hex 32` and saving the output.
+3.  [_Same as edX_] Create a _client key_ and _client secret_ for use by edX to authenticate your hub. You can do so by
+    running `openssl rand -hex 32` twice and saving each output. These keys can actually be any two strings, but for security it is recommended to use strings with [high degrees of entropy](https://xkcd.com/936).
 
-4. Create an *client secret* for use by EdX against your hub. You can do so by
-   running `openssl rand -hex 32` and saving the output.
+4.  Create an _LTI Passport String_ for use by EdX in the following format:
 
-5. Create an *LTI Passport String* for use by EdX in the following format:
+    ```
+    your-hub-name:client-key:client-secret
+    ```
 
-   ```
-   your-hub-name:client-key:client-secret
-   ```
-   
-   `your-hub-name` can be anything, but you'll need to use it later. So make it
-   something memorable and unique.
-   
-   The [add the Passport String](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#adding-an-lti-passport-to-the-course-configuration)
-   to EdX. Remember to save your changes when done!
-   
-6. Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
-   giving JupyterHub access to the client key & secret generated in steps 3 and 4.
+    `your-hub-name` can be anything, but you'll need to use it later. So make it
+    something memorable and unique.
 
-   ```python
-   c.LTIAuthenticator.consumers = {
-       "client-key": "client-secret"
-   }
-   ```
-   
-   A Hub can be configured to accept Launch requests from multiple Tool
-   Consumers. You can do so by just adding all the client keys & secrets to the
-   `c.LTIAuthenticator.consumers` traitlet like above.
-   
-7. In a Unit where you want there to be a link to the hub,
-   [add an LTI Component](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#adding-an-lti-component-to-a-course-unit).
+    The [add the Passport String](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#adding-an-lti-passport-to-the-course-configuration)
+    to EdX. Remember to save your changes when done!
 
-   You should enter the following information into the appropriate component
-   settings:
-   
-   **LTI ID**: The value you entered for `your-hub-name` in step 5.
-   
-   **LTI URL**: Should be set to `your-hub-url/hub/lti/launch`. So if your hub
-   is accessible at `http://datahub.berkeley.edu`, **LTI URL** should be
-   `http://datahub.berkeley.edu/hub/lti/launch`
-   
-   **LTI Launch Target**: Should be set to **New Window**.
-   
-   **Custom parameters**: The only currently supported custom parameter is
-   `next`, which can contain the relative URL that the user should be redirected
-   to after authentication. For example, if you are using 
-   [nbgitpuller](https://github.com/data-8/nbgitpuller) and want the user to see
-   [this file](https://github.com/binder-examples/requirements/blob/master/index.ipynb) after
-   logging in, you could set the **Custom parameters** field to the following
-   string:
-   
-   ```js
-   ["next=/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb"]
-   ```
+5.  Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
+    giving JupyterHub access to the client key & secret generated in steps 3 and 4.
 
-   Note here again that if you have a `base_url` set in your jupyterhub configuration, that should be prefixed to your next parameter. 
+    ```python
+    c.LTIAuthenticator.consumers = {
+        "client-key": "client-secret"
+    }
+    ```
 
-8. You are done! You can click the Link to see what the user workflow would look
-   like. You can repeat step 7 in all the units that should have a link to the
-   Hub for the user.
+    A Hub can be configured to accept Launch requests from multiple Tool
+    Consumers. You can do so by just adding all the client keys & secrets to the
+    `c.LTIAuthenticator.consumers` traitlet like above.
+
+6.  In a Unit where you want there to be a link to the hub,
+    [add an LTI Component](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#adding-an-lti-component-to-a-course-unit).
+
+    You should enter the following information into the appropriate component
+    settings:
+
+    **LTI ID**: The value you entered for `your-hub-name` in step 5.
+
+    **LTI URL**: Should be set to `your-hub-url/hub/lti/launch`. So if your hub
+    is accessible at `http://datahub.berkeley.edu`, **LTI URL** should be
+    `http://datahub.berkeley.edu/hub/lti/launch`
+
+    **LTI Launch Target**: Should be set to **New Window**.
+
+    **Custom parameters**: The only currently supported custom parameter is
+    `next`, which can contain the relative URL that the user should be redirected
+    to after authentication. For example, if you are using
+    [nbgitpuller](https://github.com/data-8/nbgitpuller) and want the user to see
+    [this file](https://github.com/binder-examples/requirements/blob/master/index.ipynb) after
+    logging in, you could set the **Custom parameters** field to the following
+    string:
+
+    ```js
+    [
+      'next=/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb'
+    ];
+    ```
+
+    Note here again that if you have a `base_url` set in your jupyterhub configuration, that should be prefixed to your next parameter.
+
+7.  You are done! You can click the Link to see what the user workflow would look
+    like. You can repeat step 7 in all the units that should have a link to the
+    Hub for the user.
 
 ## Canvas
 
 The setup for Canvas is very similar to the process for edX.
 
-1.  To start, you must have administrative access to Canvas. Note that this is a higher permission setting than an instructor. You may need to contact someone at your institution for assistance.
+1.  [_Same as edX_] Create a _client key_ and _client secret_ for use by Canvas to authenticate your hub. You can do so by
+    running `openssl rand -hex 32` twice and saving each output. These keys can actually be any two strings, but for security it is recommended to use strings with [high degrees of entropy](https://xkcd.com/936).
 
-2.  [_Same as edX_] Create an _client key_ for use by EdX against your hub. You can do so by
-    running `openssl rand -hex 32` and saving the output.
+2.  Create an application called "Jupyter" in Canvas. Note that the right to create applications might be limited by your
+    institution. The basic information required to create an application in Canvas' "Manual entry" mode is:
 
-3.  [_Same as edX_] Create an _client secret_ for use by EdX against your hub. You can do so by
-    running `openssl rand -hex 32` and saving the output.
+    - **Name**
+    - **Consumer Key** - from step 1
+    - **Secret Key** - from step 2
+    - **Launch URL** - `https://www.example.com/hub/lti/launch`
+    - **Domain** - optional
+    - **Privacy** - anonymous, email only, name only, or public
+    - **Custom Fields** - optional-
 
-4.  Add an external tool at the application or course level. This requires 3 inputs:
+    There are other configuration types, eg. "Paste XML" which has more controls
 
-    1. **LTI Launch URL**: `https://www.example.com/hub/lti/launch`. 
-    2. **LTI Client Key** from step 2. 
-    3. **LTI Client Secret** from step 3. 
+    The application can be created at the account level or the course level. If the application is created at the account level, it means that the application is available to all courses under the same account.
 
-5.  [Same as edX] Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
+3.  [Same as edX] Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
     giving JupyterHub access to the client key & secret generated in steps 3 and 4.
 
     _Note: While you could paste these keys directly into your configuration file, they are secure credentials and should not be committed to any version control repositories. It is therefore best practice to store them securely. Here, we have stored them in environment variables._
@@ -131,14 +134,14 @@ The setup for Canvas is very similar to the process for edX.
     Consumers. You can do so by just adding all the client keys & secrets to the
     `c.LTIAuthenticator.consumers` traitlet like above.
 
-6.  Create a new assignment.
+4.  Create a new assignment.
 
-    1. Make the submission type an external tool  
-    2. **IMPORTANT:** Click "Find" and search for the tool you added in step 4. Click that, and it will prepopulate the URL you supplied. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
-    3. Check the "Launch in a new window" checkbox.  
-    4. Append any custom parameters you wish (see next step)
+    1.  Make the submission type an external tool
+    2.  **IMPORTANT:** Click "Find" and search for the tool you added in step 4. Click that, and it will prepopulate the URL you supplied. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
+    3.  Check the "Launch in a new window" checkbox.
+    4.  Append any custom parameters you wish (see next step)
 
-7.  **Custom Parameters**. Unfortunately, Canvas does not currently support sending custom parameters as form data in launch requests (as edX does). However, you can still attach custom parameters to launch requests with query strings. Unfortunately, these parameters must be escaped with [URL escape codes](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding). You can perform this encoding manually, or you can use an online tool [such as this one](https://meyerweb.com/eric/tools/dencoder/).
+5.  **Custom Parameters**. Apart from any custom fields you have defined in step 1, you can add custom parameters to any assignment. Unlike EdX, there is no method to include these custom parameters in the lti launch request form data. However, you can append custom parameters to the launch URL as query strings--using proper [character encoding](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) to preserve the query strings as they are passed through JupyterHub. You can perform this encoding manually, or you can use an online tool [such as this one](https://meyerweb.com/eric/tools/dencoder/).
 
     Before:
 
@@ -152,11 +155,11 @@ The setup for Canvas is very similar to the process for edX.
     https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull%3Frepo%3Dhttps%3A%2F%2Fgithub.com%2Fbinder-examples%2Frequirements%26subPath%3Dindex.ipynb
     ```
 
-    Note that the _entire_ query string should not need to be escaped, just the portion that will be invoked after the `user-redirect`.
+    Note that the _entire_ query string should not need to be escaped, just the portion that will be invoked after JupyterHub processes the `user-redirect` command.
 
-8. [_Same as edX_] You are done! You can click the Link to see what the user workflow would look
-   like. You can repeat step 7 in all the units that should have a link to the
-   Hub for the user.
+6.  [_Same as edX_] You are done! You can click the link to see what the user workflow would look
+    like. You can repeat step 7 in all the units that should have a link to the
+    Hub for the user.
 
 ## Debugging Note
 
@@ -164,13 +167,13 @@ JupyterHub preferentially uses any user_id cookie stored over an authentication 
 
 ## Common Gotchas
 
-1. If you have a base_url set in your jupyterhub configruation, this needs to be reflected in your launch URL and custom parameters. For example, if your `jupyterhub_config.py` file contains:
+1.  If you have a base_url set in your jupyterhub configruation, this needs to be reflected in your launch URL and custom parameters. For example, if your `jupyterhub_config.py` file contains:
 
     ```python
     `c.JupyterHub.base_url = '/jupyter'`
     ```
 
-    then your Launch URL would be: 
+    then your Launch URL would be:
 
     ```
     https://www.example.com/jupyter/hub/lti/launch
@@ -179,5 +182,7 @@ JupyterHub preferentially uses any user_id cookie stored over an authentication 
     A custom next parameter might look like:
 
     ```js
-    ["next=/jupyter/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb"]
+    [
+      'next=/jupyter/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb'
+    ];
     ```

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ _A note about LTI Passports: These can essentially be any 3 strings put together
    string:
    
    ```js
-   ["next=/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb"]
+   ["next=/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb"]
    ```
+
+   Note here again that if you have a `base_url` set in your jupyterhub configuration, that should be prefixed to your next parameter. 
 
 8. You are done! You can click the Link to see what the user workflow would look
    like. You can repeat step 7 in all the units that should have a link to the
@@ -107,7 +109,11 @@ The setup for Canvas is very similar to the process for edX.
 3.  [_Same as edX_] Create an _client secret_ for use by EdX against your hub. You can do so by
     running `openssl rand -hex 32` and saving the output.
 
-4.  Add an external tool at the application or course level. Your can use your entire launch URL as the link, or simply use the domain name of your JupyterHub installation. The only difference is what will be prepopulated when you add the link to an assignment. Input your key and secret here as well--these will be sent in the body of every launch request.
+4.  Add an external tool at the application or course level. This requires 3 inputs:
+
+    1. **LTI Launch URL**: `https://www.example.com/hub/lti/launch`. 
+    2. **LTI Client Key** from step 2. 
+    3. **LTI Client Secret** from step 3. 
 
 5.  [Same as edX] Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
     giving JupyterHub access to the client key & secret generated in steps 3 and 4.
@@ -155,3 +161,17 @@ The setup for Canvas is very similar to the process for edX.
 ## Debugging Note
 
 JupyterHub preferentially uses any user_id cookie stored over an authentication request. Therefore, do not open multiple tabs at once and expect to be able to log in as separate users without logging out first! [Discussion](https://github.com/jupyterhub/jupyterhub/pull/1840)
+
+## Common Gotchas
+
+1. If you have a base_url (`c.JupyterHub.base_url`) set in your `jupyterhub_config.py`, this needs to be included in your launch URL and custom parameters. For example, if `c.JupyterHub.base_url = '/jupyter'`,then your Launch URL would be: 
+
+    ```
+    https://www.example.com/hub/lti/launch
+    ```
+
+    A custom next parameter might look like:
+
+    ```js
+    ["next=/jupyter/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb"]
+    ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,13 @@ JupyterHub preferentially uses any user_id cookie stored over an authentication 
 
 ## Common Gotchas
 
-1. If you have a base_url (`c.JupyterHub.base_url`) set in your `jupyterhub_config.py`, this needs to be included in your launch URL and custom parameters. For example, if `c.JupyterHub.base_url = '/jupyter'`,then your Launch URL would be: 
+1. If you have a base_url set in your jupyterhub configruation, this needs to be reflected in your launch URL and custom parameters. For example, if your `jupyterhub_config.py` file contains:
+
+    ```python
+    `c.JupyterHub.base_url = '/jupyter'`
+    ```
+    
+    then your Launch URL would be: 
 
     ```
     https://www.example.com/jupyter/hub/lti/launch

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ pip install jupyterhub-ltiauthenticator
 
 ## Using LTIAuthenticator
 
-_A note about LTI Passports: These can essentially be any 3 strings put together, but it is recommended to use the OpenSSL PRNG to create a pseudorandom 32 byte number._
-
 ### EdX
 
 1.  You need access to [EdX Studio](https://studio.edx.org/) to set up LTI. You
@@ -34,27 +32,43 @@ _A note about LTI Passports: These can essentially be any 3 strings put together
 2.  [Enable LTI Components](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#enabling-lti-components-for-a-course)
     for your course.
 
-3.  [_Same as edX_] Create a _client key_ and _client secret_ for use by edX to authenticate your hub. You can do so by
-    running `openssl rand -hex 32` twice and saving each output. These keys can actually be any two strings, but for security it is recommended to use strings with [high degrees of entropy](https://xkcd.com/936).
+3.  Create a _client key_ and _client secret_ for use by edX to authenticate your hub. Open up any command line:
 
-4.  Create an _LTI Passport String_ for use by EdX in the following format:
+    1.  Run `openssl rand -hex 32` and save the output. This will be your LTI Client **Key**.
+    2.  Run `openssl rand -hex 32` and save the output. This will be your LTI Client **Secret**.
+
+    Now we will use these strings to allow edX and JupyterHub to authenticate each other.
+
+    _Note_: These commands will simply generate strings for you, it will not store them anywhere on the computer. Therefore you do not need to run these commands on your JupyterHub server--we will be supplying them manually in the next few steps.
+
+    _Note_: Anyone with these two strings will be able to access your hub, so keep them secure!!
+
+4.  Pick a name for edX to call your JupyterHub server. Then, along with the two random strings you generated in step 3, paste them together to create an _LTI Passport String_ in the following format:
 
     ```
     your-hub-name:client-key:client-secret
     ```
 
-    `your-hub-name` can be anything, but you'll need to use it later. So make it
-    something memorable and unique.
+    `your-hub-name` can be anything, but you'll be using it throughout edX to refer to your hub, so make it something meaningful and unique.
 
-    The [add the Passport String](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#adding-an-lti-passport-to-the-course-configuration)
+    Here's an example:
+
+    ```
+    stat100-jupyterhub:fca69fa2deda7d45dfdfa85f288d59b4b5f3d22bfca2ba891187fe5c551705a5:8ce3caca82f467f0896b92d548dfbddaca86edfcaaba8c9d6777dfae4d2e1db9
+    ```
+
+    Then [add the Passport String](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#adding-an-lti-passport-to-the-course-configuration)
     to EdX. Remember to save your changes when done!
 
 5.  Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
-    giving JupyterHub access to the client key & secret generated in steps 3 and 4.
+    supplying JupyterHub with the client key & secret generated in step 3 (you don't need the hub name from step 4).
+
+    _Note: While you could paste these keys directly into your configuration file, they are secure credentials and should not be committed to any version control repositories. It is therefore best practice to store them securely. Here, we have stored them in environment variables._
 
     ```python
+    c.JupyterHub.authenticator_class = 'ltiauthenticator.LTIAuthenticator'
     c.LTIAuthenticator.consumers = {
-        "client-key": "client-secret"
+        os.environ['LTI_CLIENT_KEY']: os.environ['LTI_CLIENT_SECRET']
     }
     ```
 
@@ -68,7 +82,7 @@ _A note about LTI Passports: These can essentially be any 3 strings put together
     You should enter the following information into the appropriate component
     settings:
 
-    **LTI ID**: The value you entered for `your-hub-name` in step 5.
+    **LTI ID**: The value you entered for `your-hub-name` in step 4.
 
     **LTI URL**: Should be set to `your-hub-url/hub/lti/launch`. So if your hub
     is accessible at `http://datahub.berkeley.edu`, **LTI URL** should be
@@ -90,36 +104,49 @@ _A note about LTI Passports: These can essentially be any 3 strings put together
     ];
     ```
 
-    Note here again that if you have a `base_url` set in your jupyterhub configuration, that should be prefixed to your next parameter.
+    _Note_: If you have a `base_url` set in your jupyterhub configuration, that should be prefixed to your next parameter. ([Further explanation](#common-gotchas))
 
 7.  You are done! You can click the Link to see what the user workflow would look
-    like. You can repeat step 7 in all the units that should have a link to the
+    like. You can repeat step 6 in all the units that should have a link to the
     Hub for the user.
 
 ## Canvas
 
 The setup for Canvas is very similar to the process for edX.
 
-1.  [_Same as edX_] Create a _client key_ and _client secret_ for use by Canvas to authenticate your hub. You can do so by
-    running `openssl rand -hex 32` twice and saving each output. These keys can actually be any two strings, but for security it is recommended to use strings with [high degrees of entropy](https://xkcd.com/936).
+_Note_: You will see **Client Key** and **Consumer Key** used interchangably.
 
-2.  Create an application called "Jupyter" in Canvas. Note that the right to create applications might be limited by your
+_Note_: You will see **Client Secret** and **Secret Key** used interchangably.
+
+1.  Create a _client key_ and _client secret_ for use by Canvas to authenticate your hub. Open up any command line:
+
+    1.  Run `openssl rand -hex 32` and save the output. This will be your LTI Client **Key**.
+    2.  Run `openssl rand -hex 32` and save the output. This will be your LTI Client **Secret**.
+
+    Now we will use these strings to allow Canvas and JupyterHub to authenticate each other.
+
+    _Note_: These commands will simply generate strings for you, it will not store them anywhere on the computer. Therefore you do not need to run these commands on your JupyterHub server--we will be supplying them manually in the next few steps.
+
+    _Note_: Anyone with these two strings will be able to access your hub, so keep them secure!!
+
+2.  Create an application in Canvas. You can name it anything but you'll be using it throughout Canvas to refer to your hub, so make it
+    something meaningful and unique. Note that the right to create applications might be limited by your
     institution. The basic information required to create an application in Canvas' "Manual entry" mode is:
 
     - **Name**
     - **Consumer Key** - from step 1
-    - **Secret Key** - from step 2
+    - **Secret Key** - from step 1
     - **Launch URL** - `https://www.example.com/hub/lti/launch`
     - **Domain** - optional
     - **Privacy** - anonymous, email only, name only, or public
-    - **Custom Fields** - optional-
+    - **Custom Fields** - optional
 
-    There are other configuration types, eg. "Paste XML" which has more controls
+    There are other configuration types, eg. "Paste XML" which offer more options.
 
     The application can be created at the account level or the course level. If the application is created at the account level, it means that the application is available to all courses under the same account.
 
-3.  [Same as edX] Configure JupyterHub to accept LTI Launch requests from EdX. You do this by
-    giving JupyterHub access to the client key & secret generated in steps 3 and 4.
+3.  Configure JupyterHub to accept LTI Launch requests from Canvas. You do this by
+    supplying JupyterHub with the client key & secret generated in step 1.
 
     _Note: While you could paste these keys directly into your configuration file, they are secure credentials and should not be committed to any version control repositories. It is therefore best practice to store them securely. Here, we have stored them in environment variables._
 
@@ -137,11 +164,11 @@ The setup for Canvas is very similar to the process for edX.
 4.  Create a new assignment.
 
     1.  Make the submission type an external tool
-    2.  **IMPORTANT:** Click "Find" and search for the tool you added in step 4. Click that, and it will prepopulate the URL you supplied. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
+    2.  **IMPORTANT:** Click "Find" and search for the tool you added in step 2. Click that and it will prepopulate the URL field with the one you supplied when creating the application. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
     3.  Check the "Launch in a new window" checkbox.
     4.  Append any custom parameters you wish (see next step)
 
-5.  **Custom Parameters**. Apart from any custom fields you have defined in step 1, you can add custom parameters to any assignment. Unlike EdX, there is no method to include these custom parameters in the lti launch request form data. However, you can append custom parameters to the launch URL as query strings--using proper [character encoding](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) to preserve the query strings as they are passed through JupyterHub. You can perform this encoding manually, or you can use an online tool [such as this one](https://meyerweb.com/eric/tools/dencoder/).
+5.  **Custom Parameters**. Apart from any custom fields you have defined in step 2, you can add custom parameters to any assignment. Unlike EdX, there is no method to include these custom parameters in the lti launch request's form data. However, you can append custom parameters to the launch URL as query strings using proper [character encoding](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) to preserve the query strings as they are passed through JupyterHub. You can perform this encoding manually, [programmatically](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode), or via an online tool.
 
     Before:
 
@@ -157,13 +184,13 @@ The setup for Canvas is very similar to the process for edX.
 
     Note that the _entire_ query string should not need to be escaped, just the portion that will be invoked after JupyterHub processes the `user-redirect` command.
 
-6.  [_Same as edX_] You are done! You can click the link to see what the user workflow would look
+6.  You are done! You can click the link to see what the user workflow would look
     like. You can repeat step 7 in all the units that should have a link to the
     Hub for the user.
 
-## Debugging Note
+## Notes
 
-JupyterHub preferentially uses any user_id cookie stored over an authentication request. Therefore, do not open multiple tabs at once and expect to be able to log in as separate users without logging out first! [Discussion](https://github.com/jupyterhub/jupyterhub/pull/1840)
+1.  JupyterHub preferentially uses any user_id cookie stored over an authentication request. Therefore, do not open multiple tabs at once and expect to be able to log in as separate users without logging out first! [Discussion](https://github.com/jupyterhub/jupyterhub/pull/1840)
 
 ## Common Gotchas
 
@@ -186,3 +213,5 @@ JupyterHub preferentially uses any user_id cookie stored over an authentication 
       'next=/jupyter/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb'
     ];
     ```
+
+2.  [401 Unauthorized] - [Canvas] Make sure you added your JupyterHub link by first specifying the tool via the 'Find' button (Step 4.2). Otherwise your link will not be sending the appropriate key and secret and your launch request will be recognized as unauthorized.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This converts JupyterHub into a LTI **Tool Provider**, which can be
 then easily used with various **Tool Consumers**, such as Canvas, EdX,
 Moodle, Blackboard, etc.
 
-It's only been tested with [EdX](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html) so far,
-but compatibility with other Tool Consumers is expected to already work.
-Documentation contributions are highly welcome!
+So far, `ltiauthenticator` has been tested with [EdX](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html) and [Canvas](https://canvas.instructure.com/doc/api/file.tools_intro.html). Documentation contributions are highly welcome!
 
 Note that with this authenticator, going directly to the hub url will no longer
 allow you to log in. You *must* visit the hub through an appropriate Tool

--- a/README.md
+++ b/README.md
@@ -140,19 +140,19 @@ The setup for Canvas is very similar to the process for edX.
 
 7.  **Custom Parameters**. Unfortunately, Canvas does not currently support sending custom parameters as form data in launch requests (as edX does). However, you can still attach custom parameters to launch requests with query strings. Unfortunately, these parameters must be escaped with [URL escape codes](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding). You can perform this encoding manually, or you can use an online tool [such as this one](https://meyerweb.com/eric/tools/dencoder/).
 
-    - Before:
+    Before:
 
     ```
     https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb
     ```
 
-    - After:
+    After:
 
     ```
     https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull%3Frepo%3Dhttps%3A%2F%2Fgithub.com%2Fbinder-examples%2Frequirements%26subPath%3Dindex.ipynb
     ```
 
-    - Note that the _entire_ query string should not need to be escaped, just the portion that will be invoked after the `user-redirect`.
+    Note that the _entire_ query string should not need to be escaped, just the portion that will be invoked after the `user-redirect`.
 
 8. [_Same as edX_] You are done! You can click the Link to see what the user workflow would look
    like. You can repeat step 7 in all the units that should have a link to the
@@ -169,7 +169,7 @@ JupyterHub preferentially uses any user_id cookie stored over an authentication 
     ```python
     `c.JupyterHub.base_url = '/jupyter'`
     ```
-    
+
     then your Launch URL would be: 
 
     ```

--- a/README.md
+++ b/README.md
@@ -134,19 +134,17 @@ The setup for Canvas is very similar to the process for edX.
 
 7.  **Custom Parameters**. Unfortunately, Canvas does not currently support sending custom parameters as form data in launch requests (as edX does). However, you can still attach custom parameters to launch requests with query strings. Unfortunately, these parameters must be escaped with [URL escape codes](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding). You can perform this encoding manually, or you can use an online tool [such as this one](https://meyerweb.com/eric/tools/dencoder/).
 
-    - Example:
+    - Before:
 
-      - Before:
+    ```
+    https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb
+    ```
 
-        ```
-        https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull?repo=https://github.com/binder-examples/requirements&subPath=index.ipynb
-        ```
+    - After:
 
-      - After:
-
-        ```
-        https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull%3Frepo%3Dhttps%3A%2F%2Fgithub.com%2Fbinder-examples%2Frequirements%26subPath%3Dindex.ipynb
-        ```
+    ```
+    https://example.com/hub/lti/launch?custom_next=/hub/user-redirect/git-pull%3Frepo%3Dhttps%3A%2F%2Fgithub.com%2Fbinder-examples%2Frequirements%26subPath%3Dindex.ipynb
+    ```
 
     - Note that the _entire_ query string should not need to be escaped, just the portion that will be invoked after the `user-redirect`.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The setup for Canvas is very similar to the process for edX.
     `c.LTIAuthenticator.consumers` traitlet like above.
 
 6.  Create a new assignment.
+
     i. Make the submission type an external tool  
     ii. **IMPORTANT:** Click "Find" and search for the tool you added in step 4. Click that, and it will prepopulate the URL you supplied. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
     iii. Check the "Launch in a new window" checkbox.  

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ JupyterHub preferentially uses any user_id cookie stored over an authentication 
 1. If you have a base_url (`c.JupyterHub.base_url`) set in your `jupyterhub_config.py`, this needs to be included in your launch URL and custom parameters. For example, if `c.JupyterHub.base_url = '/jupyter'`,then your Launch URL would be: 
 
     ```
-    https://www.example.com/hub/lti/launch
+    https://www.example.com/jupyter/hub/lti/launch
     ```
 
     A custom next parameter might look like:

--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ The setup for Canvas is very similar to the process for edX.
 
 6.  Create a new assignment.
 
-    i. Make the submission type an external tool  
-    ii. **IMPORTANT:** Click "Find" and search for the tool you added in step 4. Click that, and it will prepopulate the URL you supplied. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
-    iii. Check the "Launch in a new window" checkbox.  
-    iv. Append any custom parameters you wish (see next step)
+    1. Make the submission type an external tool  
+    2. **IMPORTANT:** Click "Find" and search for the tool you added in step 4. Click that, and it will prepopulate the URL you supplied. Using the "find" button to search for your tool is necessary to ensure the LTI key and secret are sent with the launch request.
+    3. Check the "Launch in a new window" checkbox.  
+    4. Append any custom parameters you wish (see next step)
 
 7.  **Custom Parameters**. Unfortunately, Canvas does not currently support sending custom parameters as form data in launch requests (as edX does). However, you can still attach custom parameters to launch requests with query strings. Unfortunately, these parameters must be escaped with [URL escape codes](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding). You can perform this encoding manually, or you can use an online tool [such as this one](https://meyerweb.com/eric/tools/dencoder/).
 


### PR DESCRIPTION
This PR contains instructions for getting Canvas and JupyterHub talking via `ltiauthenticator`. 

I have also introduced some changes to wording and explicit clarifications about some things that confused me when setting up authentication.