### PR TITLE
[WIP] Log old users out when new user logs in

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ _Note_: You will see **Client Secret** and **Secret Key** used interchangably.
 
 ## Notes
 
-1.  JupyterHub preferentially uses any user_id cookie stored over an authentication request. Therefore, do not open multiple tabs at once and expect to be able to log in as separate users without logging out first! [Discussion](https://github.com/jupyterhub/jupyterhub/pull/1840)
+1. JupyterHub will only remember your *latest* login across all tabs / windows, so if you launch from a new course it
+   will forget the login for the old course. Use this with care!
 
 ## Common Gotchas
 


### PR DESCRIPTION
Current Behavior is:

1. User launches into a notebook from an LTI link in course A. 
   This creates a course specific user ID for the user by default.
2. Same user launches into a different notebook from a *different* 
   LTI link in course B. This creates a different course specific 
   ID for the user, *but* does not log them out of the user ID 
   created in 1! So files, etc end up in the wrong place.

The solution here is to log them out, and redirect them back to ourselves
to log them back in. This feels a little icky, but does what we want.