### PR TITLE
Remove python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 python:
   - 3.6
   - 3.5
-  - 3.4
 
 # install dependencies
 install:

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     author_email='yuvipanda@gmail.com',
     license='3 Clause BSD',
     packages=find_packages(),
+    python_requires=">=3.5",
     install_requires=[
         'jupyterhub>=0.8',
         'oauthlib==2.*'


### PR DESCRIPTION
JupyterHub no longer supports 3.4 either.
This lets us use the `async def` syntax