### PR TITLE
Bump oauthlib dependency

### DIFF
--- a/ltiauthenticator/__init__.py
+++ b/ltiauthenticator/__init__.py
@@ -78,9 +78,9 @@ class LTILaunchValidator:
             else:
                 args_list.append((key, values))
 
-        base_string = signature.construct_base_string(
+        base_string = signature.signature_base_string(
             'POST',
-            signature.normalize_base_string_uri(launch_url),
+            signature.base_string_uri(launch_url),
             signature.normalize_parameters(
                 signature.collect_parameters(body=args_list, headers=headers)
             )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         'jupyterhub>=0.8',
-        'oauthlib==2.*'
+        'oauthlib>=3.0'
     ]
 )

--- a/tests/test_lti.py
+++ b/tests/test_lti.py
@@ -16,9 +16,9 @@ def make_args(
 
     args.update(extra_args)
 
-    base_string = signature.construct_base_string(
+    base_string = signature.signature_base_string(
         'POST',
-        signature.normalize_base_string_uri(launch_url),
+        signature.base_string_uri(launch_url),
         signature.normalize_parameters(
             signature.collect_parameters(body=args, headers={})
         )


### PR DESCRIPTION
The dependency of oauthlib is too restrictive to work with JupyterHub
1.0.0 or at least the JupyterHub master.

```
ERROR: requests-oauthlib 1.2.0 has requirement oauthlib>=3.0.0, but you'll have oauthlib 2.1.0 which is incompatible.
ERROR: jupyterhub 1.0.1.dev0 has requirement oauthlib>=3.0, but you'll have oauthlib 2.1.0 which is incompatible.
```

oauthlib is used very limited in this package it seems, mainly regarding
a signature of some kind. The only import made from oauthlib is this
this:

```
from oauthlib.oauth1.rfc5849 import signature
```

The changelog:
https://github.com/oauthlib/oauthlib/blob/master/CHANGELOG.rst

But the changelog didn't capture all breaking changes, so i used git blame:
https://github.com/oauthlib/oauthlib/blame/master/oauthlib/oauth1/rfc5849/signature.py

Relevant commits:
https://github.com/oauthlib/oauthlib/commit/42023d8303113073e31a57e1bbf70216b7120e20
https://github.com/oauthlib/oauthlib/commit/0ef0a9c4342dfee4bd3aef7d6d9fa09e7226a732
https://github.com/oauthlib/oauthlib/commit/d55944aed4899011a15684efcdf603894dedd495

I renamed some functions, and hope that the signature related changes
doesn't break something for someone, but if it does, that this commit
message should help them find the related upstream changes.

## Related
Closes #23 
Closes #21
Closes #19 (it seems likely to me at least, and suggest we reopen it if not) 