### PR TITLE
Fix typo - self.request should be handler.request

### DIFF
--- a/ltiauthenticator/__init__.py
+++ b/ltiauthenticator/__init__.py
@@ -138,7 +138,7 @@ class LTIAuthenticator(Authenticator):
             hops = [h.strip() for h in handler.request.headers['x-forwarded-proto'].split(',')]
             protocol = hops[0]
         else:
-            protocol = self.request.protocol
+            protocol = handler.request.protocol
 
         launch_url = protocol + "://" + handler.request.host + handler.request.uri
 


### PR DESCRIPTION
This fixes #22 and is described in https://github.com/jupyterhub/ltiauthenticator/issues/22#issuecomment-562848326.