### PR TITLE
Log out old user when new user logs in

### DIFF
--- a/ltiauthenticator/__init__.py
+++ b/ltiauthenticator/__init__.py
@@ -184,6 +184,12 @@ class LTIAuthenticateHandler(BaseHandler):
     that URL after authentication. Else, will send them to /home.
     """
 
+    def set_login_cookie(self, user):
+        super().set_login_cookie(user)
+
+        ## Make sure that hub cookie is always set, even if the user was already logged in
+        self.set_hub_cookie(user)
+
     @gen.coroutine
     def post(self):
         """


### PR DESCRIPTION
This PR is an attempt to fix the existing issue that is described here: 
https://github.com/jupyterhub/ltiauthenticator/issues/11
Also there is an existing opened PR for it
https://github.com/jupyterhub/ltiauthenticator/pull/16
But as far as I can see it is quite old, WIP and still opened 

**More in depth description:**
JupyterHub does not set cookies for users after log in if they were previously already set. Which results in situation when attempt of new user to log in via /hub/lti/launch will be discarded if he previously was already logged in under different account