### PR TITLE
Add username_key as an LTI 1.1 Authenticator configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,20 @@ pip install jupyterhub-ltiauthenticator
 
     _Note_: Anyone with these two strings will be able to access your hub, so keep them secure!!
 
-4.  Pick a name for edX to call your JupyterHub server. Then, along with the two random strings you generated in step 3, paste them together to create an _LTI Passport String_ in the following format:
+4. By default, the user's name will be the `custom_canvas_user_id` passed in by canvas. If you
+   would like to use some other bit of information from the LTI request, you can pick what should
+   be used as the user id.
+
+   ```python
+   # Set the user's email as their user id
+   c.LTIAuthenticator.user_id_key = 'lis_person_contact_email_primary'
+   ```
+
+   A [partial list of keys in an LTI request](https://www.edu-apps.org/code.html#params)
+   is available to help. Your LMS provider might also implement custom keys
+   you can use.
+
+5.  Pick a name for edX to call your JupyterHub server. Then, along with the two random strings you generated in step 4, paste them together to create an _LTI Passport String_ in the following format:
 
     ```
     your-hub-name:client-key:client-secret

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install jupyterhub-ltiauthenticator
 
    ```python
    # Set the user's email as their user id
-   c.LTIAuthenticator.user_id_key = 'lis_person_contact_email_primary'
+   c.LTIAuthenticator.username_key = 'lis_person_contact_email_primary'
    ```
 
    A [partial list of keys in an LTI request](https://www.edu-apps.org/code.html#params)

--- a/ltiauthenticator/lti11/auth.py
+++ b/ltiauthenticator/lti11/auth.py
@@ -14,25 +14,6 @@ from ltiauthenticator.utils import convert_request_to_dict
 from ltiauthenticator.utils import get_client_protocol
 
 
-class LTI11UsernameException(Exception):
-    """Exception raised for errors in the input salary.
-
-    Attributes:
-        username (str): the username set by one of the username_key configurable from the LTI launch
-          request arguments.
-        message (str): the message returned when encountering this exception.
-    """
-
-    def __init__(
-        self,
-        username: str,
-        message: str = "None of the arguments in the launch request match the username_key configurable.",
-    ) -> None:
-        self.username = username
-        self.message = message
-        super().__init__(self.message)
-
-
 class LTI11Authenticator(Authenticator):
     """
     JupyterHub LTI 1.1 Authenticator which extends the ltiauthenticator.LTIAuthenticator class.

--- a/ltiauthenticator/lti11/auth.py
+++ b/ltiauthenticator/lti11/auth.py
@@ -3,6 +3,8 @@ from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
 
+from textwrap import dedent
+
 from tornado.web import HTTPError
 
 from traitlets.config import Dict
@@ -47,11 +49,19 @@ class LTI11Authenticator(Authenticator):
         Some common examples include:
           - User's email address: lis_person_contact_email_primary
           - Canvas LMS custom user id: custom_canvas_user_id
-        Your LMS (Canvas / Open EdX / Moodle / others) may provide additional keys in the LTI 1.1 launch request that you can use to set the username. In most cases these
-        are prefixed with `custom_`. You may also have the option of using variable substitutions to fetch values that aren't provided with your vendor's standard LTI 1.1 launch request.
-        Reference the IMS LTI specification on variable substitutions: https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-9.
+        Your LMS (Canvas / Open EdX / Moodle / others) may provide additional keys in the
+        LTI 1.1 launch request that you can use to set the username. In most cases these
+        are prefixed with `custom_`. You may also have the option of using variable substitutions
+        to fetch values that aren't provided with your vendor's standard LTI 1.1 launch request.
+        Reference the IMS LTI specification on variable substitutions:
+        https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-9.
         
-        Defaults to custom_canvas_user_id.
+        Current default behavior:
+        
+        To preserve legacy behavior, if custom_canvas_user_id is present in the LTI
+        request, it is used as the username. If not, user_id is used. In the future,
+        the default will be just user_id - if you want to use custom_canvas_user_id,
+        you must explicitly set username_key to custom_canvas_user_id.
         """,
     )
 
@@ -82,9 +92,12 @@ class LTI11Authenticator(Authenticator):
         # log deprecation warning when using the default custom_canvas_user_id setting
         if self.username_key == "custom_canvas_user_id":
             self.log.warning(
-                "The default username_key 'custom_canvas_user_id' will be replaced by 'user_id' in a future release."
+                dedent(
+                    """The default username_key 'custom_canvas_user_id' will be replaced by 'user_id' in a future release.
+                Set c.LTIAuthenticator.username_key to `custom_canvas_user_id` to preserve current behavior.
+                """
+                )
             )
-
         validator = LTI11LaunchValidator(self.consumers)
 
         self.log.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from typing import Dict
 
 from tornado.web import Application
-from tornadoweb.web import RequestHandler
+from tornado.web import RequestHandler
 from tornado.httputil import HTTPServerRequest
 
 from unittest.mock import Mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,16 +90,6 @@ def make_lti11_basic_launch_request_args() -> Dict[str, str]:
 
 
 @pytest.fixture(scope="function")
-def make_lti11_encoded_args(make_lti11_basic_launch_request_args):
-    """Create LTI 1.1 launch request with encoded args."""
-    local_args = make_lti11_basic_launch_request_args()
-    args = {}
-    for k, values in local_args.items():
-        args[k] = values[0].decode()
-    return args
-
-
-@pytest.fixture(scope="function")
 def make_lti11_success_authentication_request_args():
     def _make_lti11_success_authentication_request_args(
         roles: str = "Instructor",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import secrets
 import time
 
@@ -7,26 +8,64 @@ import pytest
 
 from typing import Dict
 
+from tornado.web import Application
+from tornadoweb.web import RequestHandler
+from tornado.httputil import HTTPServerRequest
+
+from unittest.mock import Mock
+
 
 @pytest.fixture(scope="function")
 def make_lti11_basic_launch_request_args() -> Dict[str, str]:
     def _make_lti11_basic_launch_args(
+        roles: str = "Instructor",
+        ext_roles: str = "urn:lti:instrole:ims/lis/Instructor",
+        lms_vendor: str = "canvas",
         oauth_consumer_key: str = "my_consumer_key",
         oauth_consumer_secret: str = "my_shared_secret",
     ):
         oauth_timestamp = str(int(time.time()))
         oauth_nonce = secrets.token_urlsafe(32)
         args = {
-            "lti_message_type": "basic-lti-launch-request",
-            "lti_version": "LTI-1p0".encode(),
-            "resource_link_id": "88391-e1919-bb3456",
+            "oauth_callback": "about:blank",
             "oauth_consumer_key": oauth_consumer_key,
             "oauth_timestamp": str(int(oauth_timestamp)),
             "oauth_nonce": str(oauth_nonce),
             "oauth_signature_method": "HMAC-SHA1",
-            "oauth_callback": "about:blank",
             "oauth_version": "1.0",
-            "user_id": "123123123",
+            "context_id": "888efe72d4bbbdf90619353bb8ab5965ccbe9b3f",
+            "context_label": "Introduction to Data Science",
+            "context_title": "Introduction101",
+            "course_lineitems": "https://canvas.instructure.com/api/lti/courses/1/line_items",
+            "custom_canvas_assignment_title": "test-assignment",
+            "custom_canvas_course_id": "616",
+            "custom_canvas_enrollment_state": "active",
+            "custom_canvas_user_id": "1091",
+            "custom_canvas_user_login_id": "student1@example.com",
+            "ext_roles": ext_roles,
+            "launch_presentation_document_target": "iframe",
+            "launch_presentation_height": "1000",
+            "launch_presentation_locale": "en",
+            "launch_presentation_return_url": "https://canvas.instructure.com/courses/161/external_content/success/external_tool_redirect",
+            "launch_presentation_width": "1000",
+            "lis_outcome_service_url": "http://www.imsglobal.org/developers/LTI/test/v1p1/common/tool_consumer_outcome.php?b64=MTIzNDU6OjpzZWNyZXQ=",
+            "lis_person_contact_email_primary": "student1@example.com",
+            "lis_person_name_family": "Bar",
+            "lis_person_name_full": "Foo Bar",
+            "lis_person_name_given": "Foo",
+            "lti_message_type": "basic-lti-launch-request",
+            "lis_result_sourcedid": "feb-123-456-2929::28883",
+            "lti_version": "LTI-1p0",
+            "resource_link_id": "888efe72d4bbbdf90619353bb8ab5965ccbe9b3f",
+            "resource_link_title": "Test-Assignment",
+            "roles": roles,
+            "tool_consumer_info_product_family_code": lms_vendor,
+            "tool_consumer_info_version": "cloud",
+            "tool_consumer_instance_contact_email": "notifications@mylms.com",
+            "tool_consumer_instance_guid": "srnuz6h1U8kOMmETzoqZTJiPWzbPXIYkAUnnAJ4u:test-lms",
+            "tool_consumer_instance_name": "myedutool",
+            "user_id": "185d6c59731a553009ca9b59ca3a885100000",
+            "user_image": "https://lms.example.com/avatar-50.png",
         }
         extra_args = {"my_key": "this_value"}
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -48,3 +87,118 @@ def make_lti11_basic_launch_request_args() -> Dict[str, str]:
         return args
 
     return _make_lti11_basic_launch_args
+
+
+@pytest.fixture(scope="function")
+def make_lti11_encoded_args(make_lti11_basic_launch_request_args):
+    """Create LTI 1.1 launch request with encoded args."""
+    local_args = make_lti11_basic_launch_request_args()
+    args = {}
+    for k, values in local_args.items():
+        args[k] = values[0].decode()
+    return args
+
+
+@pytest.fixture(scope="function")
+def make_lti11_success_authentication_request_args():
+    def _make_lti11_success_authentication_request_args(
+        roles: str = "Instructor",
+        ext_roles: str = "urn:lti:instrole:ims/lis/Instructor",
+        lms_vendor: str = "canvas",
+        oauth_consumer_key: str = "my_consumer_key",
+    ):
+        """
+        Return a valid request arguments make from LMS to our tool (when authentication steps were success)
+        """
+        args = {
+            "oauth_callback": ["about:blank".encode()],
+            "oauth_consumer_key": [oauth_consumer_key.encode()],
+            "oauth_signature_method": ["HMAC-SHA1".encode()],
+            "oauth_timestamp": ["1585947271".encode()],
+            "oauth_nonce": ["01fy8HKIASKuD9gK9vWUcBj9fql1nOCWfOLPzeylsmg".encode()],
+            "oauth_signature": ["abc123".encode()],
+            "oauth_version": ["1.0".encode()],
+            "context_id": ["888efe72d4bbbdf90619353bb8ab5965ccbe9b3f".encode()],
+            "context_label": ["intro101".encode()],
+            "context_title": ["intro101".encode()],
+            "course_lineitems": [
+                "my.platform.com/api/lti/courses/1/line_items".encode()
+            ],
+            "custom_canvas_assignment_title": ["test-assignment".encode()],
+            "custom_canvas_course_id": ["616".encode()],
+            "custom_canvas_enrollment_state": ["active".encode()],
+            "custom_canvas_user_id": ["1091".encode()],
+            "custom_canvas_user_login_id": ["student1@example.com".encode()],
+            "ext_roles": [ext_roles.encode()],
+            "launch_presentation_document_target": ["iframe".encode()],
+            "launch_presentation_height": ["1000".encode()],
+            "launch_presentation_locale": ["en".encode()],
+            "launch_presentation_return_url": [
+                "https: //illumidesk.instructure.com/courses/161/external_content/success/external_tool_redirect".encode()
+            ],
+            "launch_presentation_width": ["1000".encode()],
+            "lis_outcome_service_url": [
+                "http://www.imsglobal.org/developers/LTI/test/v1p1/common/tool_consumer_outcome.php?b64=MTIzNDU6OjpzZWNyZXQ=".encode()
+            ],
+            "lis_person_contact_email_primary": ["student1@example.com".encode()],
+            "lis_person_name_family": ["Bar".encode()],
+            "lis_person_name_full": ["Foo Bar".encode()],
+            "lis_person_name_given": ["Foo".encode()],
+            "lti_message_type": ["basic-lti-launch-request".encode()],
+            "lis_result_sourcedid": ["feb-123-456-2929::28883".encode()],
+            "lti_version": ["LTI-1p0".encode()],
+            "resource_link_id": ["888efe72d4bbbdf90619353bb8ab5965ccbe9b3f".encode()],
+            "resource_link_title": ["Test-Assignment-Another-LMS".encode()],
+            "roles": [roles.encode()],
+            "tool_consumer_info_product_family_code": [lms_vendor.encode()],
+            "tool_consumer_info_version": ["cloud".encode()],
+            "tool_consumer_instance_contact_email": [
+                "notifications@mylms.com".encode()
+            ],
+            "tool_consumer_instance_guid": [
+                "srnuz6h1U8kOMmETzoqZTJiPWzbPXIYkAUnnAJ4u:test-lms".encode()
+            ],
+            "tool_consumer_instance_name": ["myorg".encode()],
+            "user_id": ["185d6c59731a553009ca9b59ca3a885100000".encode()],
+            "user_image": ["https://lms.example.com/avatar-50.png".encode()],
+        }
+        return args
+
+    return _make_lti11_success_authentication_request_args
+
+
+@pytest.fixture(scope="function")
+def make_mock_request_handler() -> RequestHandler:
+    """
+    Sourced from https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/tests/mocks.py
+    """
+
+    def _make_mock_request_handler(
+        handler: RequestHandler,
+        uri: str = "https://hub.example.com",
+        method: str = "GET",
+        **settings: dict,
+    ) -> RequestHandler:
+        """Instantiate a Handler in a mock application"""
+        application = Application(
+            hub=Mock(
+                base_url="/hub/",
+                server=Mock(base_url="/hub/"),
+            ),
+            cookie_secret=os.urandom(32),
+            db=Mock(rollback=Mock(return_value=None)),
+            **settings,
+        )
+        request = HTTPServerRequest(
+            method=method,
+            uri=uri,
+            connection=Mock(),
+        )
+        handler = RequestHandler(
+            application=application,
+            request=request,
+        )
+        handler._transforms = []
+        return handler
+
+    return _make_mock_request_handler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,17 @@ from unittest.mock import Mock
 
 
 @pytest.fixture(scope="function")
+def user_model(username: str, **kwargs) -> dict:
+    """Return a user model"""
+    user = {
+        "username": username,
+        "auth_state": {k: v for k, v in kwargs.items() if not k.startswith("oauth_")},
+    }
+    user.update(kwargs)
+    return user
+
+
+@pytest.fixture(scope="function")
 def make_lti11_basic_launch_request_args() -> Dict[str, str]:
     def _make_lti11_basic_launch_args(
         roles: str = "Instructor",
@@ -158,15 +169,15 @@ def make_lti11_success_authentication_request_args():
 
 
 @pytest.fixture(scope="function")
-def make_mock_request_handler() -> RequestHandler:
+def make_lti11_mock_request_handler() -> RequestHandler:
     """
     Sourced from https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/tests/mocks.py
     """
 
-    def _make_mock_request_handler(
+    def _make_lti11_mock_request_handler(
         handler: RequestHandler,
         uri: str = "https://hub.example.com",
-        method: str = "GET",
+        method: str = "POST",
         **settings: dict,
     ) -> RequestHandler:
         """Instantiate a Handler in a mock application"""
@@ -191,4 +202,4 @@ def make_mock_request_handler() -> RequestHandler:
         handler._transforms = []
         return handler
 
-    return _make_mock_request_handler
+    return _make_lti11_mock_request_handler

--- a/tests/test_lti11_authenticator.py
+++ b/tests/test_lti11_authenticator.py
@@ -1,8 +1,108 @@
+import json
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
 import pytest
 
-from tornado import web
+from tornado.web import HTTPError
+from tornado.httputil import HTTPServerRequest
+from tornado.web import RequestHandler
 
+from ltiauthenticator.lti11.auth import LTI11Authenticator
 from ltiauthenticator.lti11.validator import LTI11LaunchValidator
+
+
+@pytest.mark.asyncio
+async def test_authenticator_uses_lti11validator(
+    make_lti11_success_authentication_request_args,
+):
+    """
+    Ensure that we call the LTI11Validator from the LTI11Authenticator.
+    """
+    with patch.object(
+        LTI11LaunchValidator, "validate_launch_request", return_value=True
+    ) as mock_validator:
+
+        authenticator = LTI11Authenticator()
+        handler = Mock(spec=RequestHandler)
+        request = HTTPServerRequest(
+            method="POST",
+            connection=Mock(),
+        )
+        handler.request = request
+
+        handler.request.arguments = make_lti11_success_authentication_request_args(
+            "lmsvendor"
+        )
+        handler.request.get_argument = (
+            lambda x, strip=True: make_lti11_success_authentication_request_args(
+                "lmsvendor"
+            )[x][0].decode()
+        )
+
+        _ = await authenticator.authenticate(handler, None)
+        assert mock_validator.called
+
+
+@pytest.mark.asyncio
+async def test_authenticator_returns_auth_state_with_other_lms_vendor(
+    make_lti11_success_authentication_request_args,
+):
+    """
+    Do we get a valid username with lms vendors other than canvas?
+    """
+    local_args = make_lti11_success_authentication_request_args()
+    local_args["custom_canvas_user_id"] = ["".encode()]
+    with patch.object(
+        LTI11LaunchValidator, "validate_launch_request", return_value=True
+    ):
+        authenticator = LTI11Authenticator()
+        handler = Mock(
+            spec=RequestHandler,
+            get_secure_cookie=Mock(return_value=json.dumps(["key", "secret"])),
+            request=Mock(
+                arguments=local_args,
+                headers={},
+                items=[],
+            ),
+        )
+        result = await authenticator.authenticate(handler, None)
+        expected = {
+            "name": "185d6c59731a553009ca9b59ca3a885100000",
+        }
+        assert result["name"] == expected["name"]
+
+
+@pytest.mark.asyncio
+async def test_authenticator_returns_correct_username_when_using_lis_person_contact_email_primary(
+    make_lti11_success_authentication_request_args,
+):
+    """
+    Do we get a valid username with lms vendors other than canvas?
+    """
+    local_args = make_lti11_success_authentication_request_args()
+    local_authenticator = LTI11Authenticator()
+    local_authenticator.username_key = "lis_person_contact_email_primary"
+
+    with patch.object(
+        LTI11LaunchValidator, "validate_launch_request", return_value=True
+    ):
+        authenticator = local_authenticator
+        handler = Mock(
+            spec=RequestHandler,
+            get_secure_cookie=Mock(return_value=json.dumps(["key", "secret"])),
+            request=Mock(
+                arguments=local_args,
+                headers={},
+                items=[],
+            ),
+        )
+        result = await authenticator.authenticate(handler, None)
+        expected = {
+            "name": "student1@example.com",
+        }
+        assert result["name"] == expected["name"]
 
 
 def test_launch(make_lti11_basic_launch_request_args):
@@ -22,7 +122,7 @@ def test_launch(make_lti11_basic_launch_request_args):
     assert validator.validate_launch_request(launch_url, headers, args)
 
 
-def test_wrong_key(make_lti11_basic_launch_request_args):
+def test_wrong_oauth_consumer_key(make_lti11_basic_launch_request_args):
     """Test that the request is rejected when receiving the wrong consumer key."""
     oauth_consumer_key = "my_consumer_key"
     oauth_consumer_secret = "my_shared_secret"
@@ -36,11 +136,11 @@ def test_wrong_key(make_lti11_basic_launch_request_args):
 
     validator = LTI11LaunchValidator({"wrongkey": oauth_consumer_secret})
 
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(HTTPError):
         assert validator.validate_launch_request(launch_url, headers, args)
 
 
-def test_wrong_secret(make_lti11_basic_launch_request_args):
+def test_wrong_oauth_consumer_secret(make_lti11_basic_launch_request_args):
     """Test that a request is rejected when the signature is created with the wrong secret."""
     oauth_consumer_key = "my_consumer_key"
     oauth_consumer_secret = "my_shared_secret"
@@ -54,8 +154,30 @@ def test_wrong_secret(make_lti11_basic_launch_request_args):
 
     validator = LTI11LaunchValidator({oauth_consumer_key: "wrongsecret"})
 
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
+
+
+@pytest.mark.asyncio
+async def test_authenticator_returns_auth_state_with_other_lms_vendor_test(
+    make_lti11_basic_launch_request_args, make_mock_request_handler
+):
+    """
+    Do we get a valid username with lms vendors other than canvas?
+    """
+    oauth_consumer_key = "my_consumer_key"
+    oauth_consumer_secret = "my_shared_secret"
+    launch_url = "http://jupyterhub/hub/lti/launch"
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+    args = make_lti11_basic_launch_request_args(
+        oauth_consumer_key,
+        oauth_consumer_secret,
+    )
+
+    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+
+    assert validator.validate_launch_request(launch_url, headers, args)
 
 
 def test_full_replay(make_lti11_basic_launch_request_args):
@@ -75,7 +197,7 @@ def test_full_replay(make_lti11_basic_launch_request_args):
 
     assert validator.validate_launch_request(launch_url, headers, args)
 
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
 
 
@@ -97,7 +219,7 @@ def test_partial_replay_timestamp(make_lti11_basic_launch_request_args):
     assert validator.validate_launch_request(launch_url, headers, args)
 
     args["oauth_timestamp"] = str(int(float(args["oauth_timestamp"])) - 1)
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
 
 
@@ -118,7 +240,7 @@ def test_partial_replay_nonce(make_lti11_basic_launch_request_args):
     assert validator.validate_launch_request(launch_url, headers, args)
 
     args["oauth_nonce"] = args["oauth_nonce"] + "1"
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
 
 
@@ -139,5 +261,5 @@ def test_dubious_extra_args(make_lti11_basic_launch_request_args):
     assert validator.validate_launch_request(launch_url, headers, args)
 
     args["extra_credential"] = "i have admin powers"
-    with pytest.raises(web.HTTPError):
+    with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)

--- a/tests/test_lti11_handlers.py
+++ b/tests/test_lti11_handlers.py
@@ -7,12 +7,12 @@ from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler
 
 @pytest.mark.asyncio
 async def test_lti_11_authenticate_handler_invokes_redirect_method(
-    make_mock_request_handler,
+    make_lti11_mock_request_handler,
 ):
     """
     Does the LTI11AuthenticateHandler call the redirect function?
     """
-    local_handler = make_mock_request_handler(LTI11AuthenticateHandler)
+    local_handler = make_lti11_mock_request_handler(LTI11AuthenticateHandler)
     with patch.object(
         LTI11AuthenticateHandler, "redirect", return_value=None
     ) as mock_redirect:
@@ -25,12 +25,12 @@ async def test_lti_11_authenticate_handler_invokes_redirect_method(
 
 @pytest.mark.asyncio
 async def test_lti_11_authenticate_handler_invokes_login_user_method(
-    make_mock_request_handler,
+    make_lti11_mock_request_handler,
 ):
     """
     Does the LTI11AuthenticateHandler call the login_user function?
     """
-    local_handler = make_mock_request_handler(LTI11AuthenticateHandler)
+    local_handler = make_lti11_mock_request_handler(LTI11AuthenticateHandler)
     with patch.object(LTI11AuthenticateHandler, "redirect", return_value=None):
         with patch.object(
             LTI11AuthenticateHandler, "login_user", return_value=None

--- a/tests/test_lti11_handlers.py
+++ b/tests/test_lti11_handlers.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+
+from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler
+
+
+@pytest.mark.asyncio
+async def test_lti_11_authenticate_handler_invokes_redirect_method(
+    make_mock_request_handler,
+):
+    """
+    Does the LTI11AuthenticateHandler call the redirect function?
+    """
+    local_handler = make_mock_request_handler(LTI11AuthenticateHandler)
+    with patch.object(
+        LTI11AuthenticateHandler, "redirect", return_value=None
+    ) as mock_redirect:
+        with patch.object(LTI11AuthenticateHandler, "login_user", return_value=None):
+            await LTI11AuthenticateHandler(
+                local_handler.application, local_handler.request
+            ).post()
+            assert mock_redirect.called
+
+
+@pytest.mark.asyncio
+async def test_lti_11_authenticate_handler_invokes_login_user_method(
+    make_mock_request_handler,
+):
+    """
+    Does the LTI11AuthenticateHandler call the login_user function?
+    """
+    local_handler = make_mock_request_handler(LTI11AuthenticateHandler)
+    with patch.object(LTI11AuthenticateHandler, "redirect", return_value=None):
+        with patch.object(
+            LTI11AuthenticateHandler, "login_user", return_value=None
+        ) as mock_login_user:
+            await LTI11AuthenticateHandler(
+                local_handler.application, local_handler.request
+            ).post()
+            assert mock_login_user.called


### PR DESCRIPTION
- Adds the `LTI11Authenticator.username_key` to set the username returned by the authenticator to something other than `custom_canvas_user_id` or `user_id` if specified
- Adds basic tests for `LTI11AuthenticateHandler` class
- Updates Readme

Continuation of #14

Closes #30 

cc/ @BenGig