### PR TITLE
Remove exception when default custom_canvas_user_id argument is not included in LTI 1.1 launch request

### DIFF
--- a/ltiauthenticator/lti11/auth.py
+++ b/ltiauthenticator/lti11/auth.py
@@ -120,10 +120,8 @@ class LTI11Authenticator(Authenticator):
 
             # raise an http error if the username_key is not in the request's arguments.
             if self.username_key not in args.keys():
-                raise HTTPError(
-                    400,
-                    "%s did not match any of the launch request arguments."
-                    % self.username_key,
+                self.log.warning(
+                    "%s the specified username_key did not match any of the launch request arguments."
                 )
 
             # get the username_key. if empty, fetch the username from the request's user_id value.

--- a/tests/test_lti11_authenticator.py
+++ b/tests/test_lti11_authenticator.py
@@ -75,6 +75,35 @@ async def test_authenticator_returns_auth_dict_when_custom_canvas_user_id_is_emp
 
 
 @pytest.mark.asyncio
+async def test_authenticator_returns_auth_dict_when_custom_canvas_user_id_does_not_exist(
+    make_lti11_success_authentication_request_args,
+):
+    """
+    Do we get a valid username when the custom_canvas_user_id parameter does not exist in the launch request?
+    """
+    local_args = make_lti11_success_authentication_request_args()
+    del local_args["custom_canvas_user_id"]
+    with patch.object(
+        LTI11LaunchValidator, "validate_launch_request", return_value=True
+    ):
+        authenticator = LTI11Authenticator()
+        handler = Mock(
+            spec=RequestHandler,
+            get_secure_cookie=Mock(return_value=json.dumps(["key", "secret"])),
+            request=Mock(
+                arguments=local_args,
+                headers={},
+                items=[],
+            ),
+        )
+        result = await authenticator.authenticate(handler, None)
+        expected = {
+            "name": "185d6c59731a553009ca9b59ca3a885100000",
+        }
+        assert result["name"] == expected["name"]
+
+
+@pytest.mark.asyncio
 async def test_authenticator_returns_correct_username_when_using_lis_person_contact_email_primary(
     make_lti11_success_authentication_request_args,
 ):


### PR DESCRIPTION
- Updates the authenticator to remove HTTPError
- Pending: add test to assert that a missing `custom_canvas_user_id` uses the `user_id` value as a fallback.

Closes #50 