### PR TITLE
README: updated k8s example

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,15 +247,10 @@ The Moodle setup is very similar to both the examples outlined above.
   hub:
     config:
       LTIAuthenticator:
-        consumers: { 
-          "client-key"": "client-secret"
-        }
+        consumers:
+          client-key: client-secret
       JupyterHub:
         authenticator_class: ltiauthenticator.LTIAuthenticator
-    extraConfig:
-      myAuthConfig: |
-        from ltiauthenticator import LTIAuthenticator
-        c.JupyterHub.authenticator_class = LTIAuthenticator
 ```
 
 7. If your Moodle environment is using https, you should also use https for your Jupyterhub.

--- a/README.md
+++ b/README.md
@@ -244,12 +244,18 @@ The Moodle setup is very similar to both the examples outlined above.
    config.yaml:
 
 ```yaml
-    auth:
-      type: "lti"
-      lti:
-          consumers: { 
-              "client-key"": "client-secret"
-              }
+  hub:
+    config:
+      LTIAuthenticator:
+        consumers: { 
+          "client-key"": "client-secret"
+        }
+      JupyterHub:
+        authenticator_class: ltiauthenticator.LTIAuthenticator
+    extraConfig:
+      myAuthConfig: |
+        from ltiauthenticator import LTIAuthenticator
+        c.JupyterHub.authenticator_class = LTIAuthenticator
 ```
 
 7. If your Moodle environment is using https, you should also use https for your Jupyterhub.

--- a/ltiauthenticator/__init__.py
+++ b/ltiauthenticator/__init__.py
@@ -1,1 +1,1 @@
-from ltiauthenticator.lti11.auth import LTI11Authenticator as LTI11Authenticator  # noqa
+from ltiauthenticator.lti11.auth import LTI11Authenticator as LTIAuthenticator  # noqa

--- a/ltiauthenticator/__init__.py
+++ b/ltiauthenticator/__init__.py
@@ -1,1 +1,1 @@
-from ltiauthenticator.lti11.auth import LTI11Authenticator as LTIAuthenticator  # noqa
+from ltiauthenticator.lti11.auth import LTI11Authenticator as LTI11Authenticator  # noqa


### PR DESCRIPTION
Changed the configuration example, replaced the outdated `auth: type: "LTI"` configuration syntax.

I also included the `extraConfig` mentioned in #50. 