### PR TITLE
Don't split up imports into one per line

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,12 +24,6 @@ repos:
       - id: black
         args: [--target-version=py36]
 
-  # Autoformat: Python code
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
-    hooks:
-      - id: reorder-python-imports
-
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.4.1


### PR DESCRIPTION
Vertical screen space is very limited and valuable, and requiring each import to be
in one line makes it difficult for me to see what is going on. Generous line length
limits should instead help with making sure we don't have overly long lines.

I am happy to try separate stdlib, external and internal imports, but would definitely
not like us to require one import per line.