### PR TITLE
Update helm chart examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add LTI 1.3 authenticator and config handler [#73](https://github.com/jupyterhub/ltiauthenticator/pull/73) ([@jgwerner](https://github.com/jgwerner))
 
-## Contributors to this release
+#### Contributors to this release
 
 ([GitHub contributors page for this release](https://github.com/jupyterhub/ltiauthenticator/graphs/contributors?from=2021-09-01&to=2021-11-15&type=c))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,4 @@ Examples:
 
 #### Releases
 
-Please refer to the documentation within this repo's [RELEASE.md](https://github.com/jupyterhub/ltiauthenticator/blob/main/RELEASE.md). The example below updates the release to `1.3.0` and outputs the results (`--verbose`):
-
-```bash
-bump2version --verbose --new-version 1.3.0 -
-```
-
-Use the `--dry-run` flag to emulate the update without actually changing the files.
+Please refer to the documentation within this repo's [RELEASE.md](https://github.com/jupyterhub/ltiauthenticator/blob/main/RELEASE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,4 +124,10 @@ Examples:
 
 #### Releases
 
-Please refer to the documentation within JupyterHub's [RELEASE.md](https://github.com/jupyterhub/jupyterhub/blob/main/RELEASE.md).
+Please refer to the documentation within JupyterHub's [RELEASE.md](https://github.com/jupyterhub/jupyterhub/blob/main/RELEASE.md). We recomment using [`bump2version`](https://github.com/c4urself/bump2version) instead of `tbump`, however. The example below updates the release to `v1.3.0` and outputs the results (`--verbose`):
+
+```bash
+bump2version --verbose --new-version 1.3.0 minor
+```
+
+Use the `--dry-run` flag to emulate the update without actually changing the files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Examples:
 
 #### Releases
 
-Please refer to the documentation within JupyterHub's [RELEASE.md](https://github.com/jupyterhub/jupyterhub/blob/main/RELEASE.md). We recomment using [`bump2version`](https://github.com/c4urself/bump2version) instead of `tbump`, however. The example below updates the release to `1.3.0` and outputs the results (`--verbose`):
+Please refer to the documentation within this repo's [RELEASE.md](https://github.com/jupyterhub/ltiauthenticator/blob/main/RELEASE.md). The example below updates the release to `1.3.0` and outputs the results (`--verbose`):
 
 ```bash
 bump2version --verbose --new-version 1.3.0 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,10 @@ Examples:
 
 #### Releases
 
-Please refer to the documentation within JupyterHub's [RELEASE.md](https://github.com/jupyterhub/jupyterhub/blob/main/RELEASE.md). We recomment using [`bump2version`](https://github.com/c4urself/bump2version) instead of `tbump`, however. The example below updates the release to `v1.3.0` and outputs the results (`--verbose`):
+Please refer to the documentation within JupyterHub's [RELEASE.md](https://github.com/jupyterhub/jupyterhub/blob/main/RELEASE.md). We recomment using [`bump2version`](https://github.com/c4urself/bump2version) instead of `tbump`, however. The example below updates the release to `1.3.0` and outputs the results (`--verbose`):
 
 ```bash
-bump2version --verbose --new-version 1.3.0 minor
+bump2version --verbose --new-version 1.3.0 -
 ```
 
 Use the `--dry-run` flag to emulate the update without actually changing the files.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ You may customize these settings with the `config_*` configuration options descr
 
 #### Custom Configuration with JupyterHub's Helm Chart
 
+##### LTI 1.1
+
 If you are running **JupyterHub within a Kubernetes Cluster**, deployed using helm, you need to supply the client key & shared secret with the `lti.consumers` key. The example below also demonstrates how customize the `lti.username_key` to set the user's email as the JupyterHub username and the `lti.config_icon` to define a custom external tool icon when using the LTI 1.1 configuration XML endpoint:
 
 ```yaml
@@ -103,7 +105,8 @@ hub:
     # Additional documentation related to authentication and authorization available at
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
-      authenticator_class: lti
+      authenticator_class: ltiauthenticator.LTIAuthenticator # LTI 1.1
+      authenticator_class: ltiauthenticator.lti13.auth.LTI13Authenticator # LTI 1.3
     LTI11Authenticator:
       consumers: { "client-key": "client-secret" }
       username_key: "lis_person_contact_email_primary"
@@ -111,6 +114,33 @@ hub:
 ```
 
 _Note_: in the helm chart example configuration above `hub.config.LTI11Authenticator.username_key: lis_person_contact_email_primary` is equivalent to the standard JupyterHub configuration using `jupyterhub_config.py` with `c.LTI11Authenticator.username_key = lis_person_contact_email_primary`.
+
+##### LTI 1.3
+
+If you are running **JupyterHub within a Kubernetes Cluster**, deployed using helm, you need to supply the LTI 1.3 (OIDC/OAuth2) endpoints. The example below also demonstrates how customize the `lti13.username_key` to set the user's give name:
+
+```yaml
+# Custom config for JupyterHub's helm chart
+hub:
+  config:
+    # Additional documentation related to authentication and authorization available at
+    # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
+    JupyterHub:
+      authenticator_class: ltiauthenticator.lti13.auth.LTI13Authenticator
+    LTI13Authenticator:
+      # Use an LTI 1.3 claim to set the username. You can use and LTI 1.3 claim that
+      # identifies the user, such as email, last_name, etc.
+      username_key: "given_name"
+      # The LTI 1.3 authorization url
+      authorize_url: "https://canvas.instructure.com/api/lti/authorize_redirect"
+      # The external tool's client id as represented within the platform (LMS)
+      # Note: the client id is not required by some LMS's for authentication.
+      client_id: "125900000000000329"
+      # The LTI 1.3 endpoint url, also known as the OAuth2 callback url
+      endpoint: "http://localhost:8000/hub/oauth_callback"
+      # The LTI 1.3 token url used to validate JWT signatures
+      token_url: "https://canvas.instructure.com/login/oauth2/token"
+```
 
 #### Configuration of LTI 1.1 with the Learning Management System
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ You may customize these settings with the `config_*` configuration options descr
 
 #### Custom Configuration with JupyterHub's Helm Chart
 
-##### LTI 1.1
-
 If you are running **JupyterHub within a Kubernetes Cluster**, deployed using helm, you need to supply the client key & shared secret with the `lti.consumers` key. The example below also demonstrates how customize the `lti.username_key` to set the user's email as the JupyterHub username and the `lti.config_icon` to define a custom external tool icon when using the LTI 1.1 configuration XML endpoint:
 
 ```yaml
@@ -106,7 +104,6 @@ hub:
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
       authenticator_class: ltiauthenticator.LTIAuthenticator # LTI 1.1
-      authenticator_class: ltiauthenticator.lti13.auth.LTI13Authenticator # LTI 1.3
     LTI11Authenticator:
       consumers: { "client-key": "client-secret" }
       username_key: "lis_person_contact_email_primary"
@@ -114,33 +111,6 @@ hub:
 ```
 
 _Note_: in the helm chart example configuration above `hub.config.LTI11Authenticator.username_key: lis_person_contact_email_primary` is equivalent to the standard JupyterHub configuration using `jupyterhub_config.py` with `c.LTI11Authenticator.username_key = lis_person_contact_email_primary`.
-
-##### LTI 1.3
-
-If you are running **JupyterHub within a Kubernetes Cluster**, deployed using helm, you need to supply the LTI 1.3 (OIDC/OAuth2) endpoints. The example below also demonstrates how customize the `lti13.username_key` to set the user's give name:
-
-```yaml
-# Custom config for JupyterHub's helm chart
-hub:
-  config:
-    # Additional documentation related to authentication and authorization available at
-    # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
-    JupyterHub:
-      authenticator_class: ltiauthenticator.lti13.auth.LTI13Authenticator
-    LTI13Authenticator:
-      # Use an LTI 1.3 claim to set the username. You can use and LTI 1.3 claim that
-      # identifies the user, such as email, last_name, etc.
-      username_key: "given_name"
-      # The LTI 1.3 authorization url
-      authorize_url: "https://canvas.instructure.com/api/lti/authorize_redirect"
-      # The external tool's client id as represented within the platform (LMS)
-      # Note: the client id is not required by some LMS's for authentication.
-      client_id: "125900000000000329"
-      # The LTI 1.3 endpoint url, also known as the OAuth2 callback url
-      endpoint: "http://localhost:8000/hub/oauth_callback"
-      # The LTI 1.3 token url used to validate JWT signatures
-      token_url: "https://canvas.instructure.com/login/oauth2/token"
-```
 
 #### Configuration of LTI 1.1 with the Learning Management System
 
@@ -336,7 +306,7 @@ You may customize these settings with the `config_*` configuration options descr
 
 #### Custom Configuration with JupyterHub's Helm Chart
 
-If you are running **JupyterHub within a Kubernetes Cluster**, deployed using helm, you need to supply the client key & shared secret with the `lti.consumers` key. The example below also demonstrates how customize the `lti.username_key` to set the user's email as the JupyterHub username and the `lti.config_icon` to define a custom external tool icon when using the LTI 1.1 configuration XML endpoint:
+If you are running **JupyterHub within a Kubernetes Cluster**, deployed using helm, you need to supply the LTI 1.3 (OIDC/OAuth2) endpoints. The example below also demonstrates how customize the `lti13.username_key` to set the user's give name:
 
 ```yaml
 # Custom config for JupyterHub's helm chart
@@ -345,14 +315,21 @@ hub:
     # Additional documentation related to authentication and authorization available at
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
-      authenticator_class: lti
-    LTI11Authenticator:
-      consumers: { "client-key": "client-secret" }
-      username_key: "lis_person_contact_email_primary"
-      config_icon: "https://my.static.assets/img/icon.jpg"
+      authenticator_class: ltiauthenticator.lti13.auth.LTI13Authenticator
+    LTI13Authenticator:
+      # Use an LTI 1.3 claim to set the username. You can use and LTI 1.3 claim that
+      # identifies the user, such as email, last_name, etc.
+      username_key: "given_name"
+      # The LTI 1.3 authorization url
+      authorize_url: "https://canvas.instructure.com/api/lti/authorize_redirect"
+      # The external tool's client id as represented within the platform (LMS)
+      # Note: the client id is not required by some LMS's for authentication.
+      client_id: "125900000000000329"
+      # The LTI 1.3 endpoint url, also known as the OAuth2 callback url
+      endpoint: "http://localhost:8000/hub/oauth_callback"
+      # The LTI 1.3 token url used to validate JWT signatures
+      token_url: "https://canvas.instructure.com/login/oauth2/token"
 ```
-
-_Note_: in the helm chart example configuration above `hub.config.LTI11Authenticator.username_key: lis_person_contact_email_primary` is equivalent to the standard JupyterHub configuration using `jupyterhub_config.py` with `c.LTI11Authenticator.username_key = lis_person_contact_email_primary`.
 
 #### Configuration of LTI 1.3 with the Learning Management System
 


### PR DESCRIPTION
- Updates helm chart configuration examples for both LTI 1.1 and LTI 1.3
- Fixes releases link in CONTRIBUTING.md
- Adds example to create a release with bump2version

Closes #72 