### PR TITLE
pre-commit: replace reorder-python-imports with isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,14 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        args: [--target-version=py36]
+        # args are not passed, but see the config in pyproject.toml
 
   # Autoformat: Python code
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
     hooks:
-      - id: reorder-python-imports
+      - id: isort
+        # args are not passed, but see the config in pyproject.toml
 
   # Autoformat: markdown, yaml
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,6 @@
 # -- Project specific imports ------------------------------------------------
 import datetime
 
-
 # -- Sphinx setup function ---------------------------------------------------
 # ref: http://www.sphinx-doc.org/en/latest/extdev/tutorial.html#the-setup-function
 

--- a/examples/jupyterhub_config_lti11.py
+++ b/examples/jupyterhub_config_lti11.py
@@ -1,7 +1,6 @@
 """ Example JupyterHub configuration file with LTI 1.1 settings. """
 import os
 
-
 # Set port and IP
 c.JupyterHub.ip = "0.0.0.0"
 c.JupyterHub.port = 8000

--- a/examples/jupyterhub_config_lti13.py
+++ b/examples/jupyterhub_config_lti13.py
@@ -1,7 +1,6 @@
 """ Example JupyterHub configuration file with LTI 1.3 settings. """
 import os
 
-
 # Set port and IP
 c.JupyterHub.ip = "0.0.0.0"
 c.JupyterHub.port = 8000

--- a/ltiauthenticator/lti11/auth.py
+++ b/ltiauthenticator/lti11/auth.py
@@ -5,14 +5,11 @@ from jupyterhub.auth import Authenticator
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import url_path_join
 from tornado.web import HTTPError
-from traitlets.config import Dict
-from traitlets.config import Unicode
+from traitlets.config import Dict, Unicode
 
-from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler
-from ltiauthenticator.lti11.handlers import LTI11ConfigHandler
+from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler, LTI11ConfigHandler
 from ltiauthenticator.lti11.validator import LTI11LaunchValidator
-from ltiauthenticator.utils import convert_request_to_dict
-from ltiauthenticator.utils import get_client_protocol
+from ltiauthenticator.utils import convert_request_to_dict, get_client_protocol
 
 
 class LTI11Authenticator(Authenticator):

--- a/ltiauthenticator/lti11/validator.py
+++ b/ltiauthenticator/lti11/validator.py
@@ -1,14 +1,12 @@
 import time
 from collections import OrderedDict
-from typing import Any
-from typing import Dict
+from typing import Any, Dict
 
 from oauthlib.oauth1.rfc5849 import signature
 from tornado.web import HTTPError
 from traitlets.config import LoggingConfigurable
 
-from .constants import LTI11_LAUNCH_PARAMS_REQUIRED
-from .constants import LTI11_OAUTH_ARGS
+from .constants import LTI11_LAUNCH_PARAMS_REQUIRED, LTI11_OAUTH_ARGS
 
 
 class LTI11LaunchValidator(LoggingConfigurable):

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -9,11 +9,12 @@ from oauthenticator.oauth2 import OAuthenticator
 from tornado.web import HTTPError
 from traitlets.config import Unicode
 
-from .handlers import LTI13CallbackHandler
-from .handlers import LTI13ConfigHandler
-from .handlers import LTI13LaunchValidator
-from .handlers import LTI13LoginHandler
-
+from .handlers import (
+    LTI13CallbackHandler,
+    LTI13ConfigHandler,
+    LTI13LaunchValidator,
+    LTI13LoginHandler,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -3,29 +3,22 @@ import json
 import os
 import re
 import uuid
-from typing import Any
-from typing import cast
-from typing import Dict
-from typing import List
-from typing import Optional
-from urllib.parse import quote
-from urllib.parse import unquote
-from urllib.parse import urlparse
+from typing import Any, Dict, List, Optional, cast
+from urllib.parse import quote, unquote, urlparse
 
 import pem
 from Crypto.PublicKey import RSA
 from jupyterhub.handlers import BaseHandler
-from oauthenticator.oauth2 import _serialize_state
-from oauthenticator.oauth2 import guess_callback_uri
-from oauthenticator.oauth2 import OAuthCallbackHandler
-from oauthenticator.oauth2 import OAuthLoginHandler
+from oauthenticator.oauth2 import (
+    OAuthCallbackHandler,
+    OAuthLoginHandler,
+    _serialize_state,
+    guess_callback_uri,
+)
 from tornado.httputil import url_concat
-from tornado.web import HTTPError
-from tornado.web import RequestHandler
+from tornado.web import HTTPError, RequestHandler
 
-from ..utils import convert_request_to_dict
-from ..utils import get_client_protocol
-from ..utils import get_jwk
+from ..utils import convert_request_to_dict, get_client_protocol, get_jwk
 from .validator import LTI13LaunchValidator
 
 

--- a/ltiauthenticator/lti13/validator.py
+++ b/ltiauthenticator/lti13/validator.py
@@ -1,18 +1,18 @@
 import json
-from typing import Any
-from typing import Dict
+from typing import Any, Dict
 
 import jwt
-from josepy.jws import Header
-from josepy.jws import JWS
+from josepy.jws import JWS, Header
 from tornado.httpclient import AsyncHTTPClient
 from tornado.web import HTTPError
 from traitlets.config import LoggingConfigurable
 
-from ltiauthenticator.lti13.constants import LTI13_DEEP_LINKING_REQUIRED_CLAIMS
-from ltiauthenticator.lti13.constants import LTI13_GENERAL_REQUIRED_CLAIMS
-from ltiauthenticator.lti13.constants import LTI13_LOGIN_REQUEST_ARGS
-from ltiauthenticator.lti13.constants import LTI13_RESOURCE_LINK_REQUIRED_CLAIMS
+from ltiauthenticator.lti13.constants import (
+    LTI13_DEEP_LINKING_REQUIRED_CLAIMS,
+    LTI13_GENERAL_REQUIRED_CLAIMS,
+    LTI13_LOGIN_REQUEST_ARGS,
+    LTI13_RESOURCE_LINK_REQUIRED_CLAIMS,
+)
 
 
 class LTI13LaunchValidator(LoggingConfigurable):

--- a/ltiauthenticator/tests/conftest.py
+++ b/ltiauthenticator/tests/conftest.py
@@ -1,8 +1,7 @@
 import os
 import secrets
 import time
-from typing import Dict
-from typing import List
+from typing import Dict, List
 from unittest.mock import Mock
 
 import jwt
@@ -11,8 +10,7 @@ from Crypto.PublicKey import RSA
 from jupyterhub.app import JupyterHub
 from oauthlib.oauth1.rfc5849 import signature
 from tornado.httputil import HTTPServerRequest
-from tornado.web import Application
-from tornado.web import RequestHandler
+from tornado.web import Application, RequestHandler
 from traitlets.config import Config
 
 

--- a/ltiauthenticator/tests/mocking.py
+++ b/ltiauthenticator/tests/mocking.py
@@ -2,8 +2,7 @@ from jupyterhub.app import JupyterHub
 from jupyterhub.handlers import BaseHandler
 
 from ltiauthenticator.lti11.auth import LTI11Authenticator
-from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler
-from ltiauthenticator.lti11.handlers import LTI11ConfigHandler
+from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler, LTI11ConfigHandler
 from ltiauthenticator.lti13.auth import LTI13Authenticator
 from ltiauthenticator.lti13.handlers import LTI13ConfigHandler
 

--- a/ltiauthenticator/tests/test_lti11_authenticator.py
+++ b/ltiauthenticator/tests/test_lti11_authenticator.py
@@ -1,15 +1,14 @@
 import json
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from tornado.httputil import HTTPServerRequest
-from tornado.web import HTTPError
-from tornado.web import RequestHandler
+from tornado.web import HTTPError, RequestHandler
 
-from .mocking import MockLTI11Authenticator
 from ltiauthenticator.lti11.auth import LTI11Authenticator
 from ltiauthenticator.lti11.validator import LTI11LaunchValidator
+
+from .mocking import MockLTI11Authenticator
 
 
 @pytest.mark.asyncio

--- a/ltiauthenticator/tests/test_lti11_handlers.py
+++ b/ltiauthenticator/tests/test_lti11_handlers.py
@@ -2,8 +2,9 @@ from unittest.mock import patch
 
 import pytest
 
-from .mocking import MockLTI11Authenticator
 from ltiauthenticator.lti11.handlers import LTI11AuthenticateHandler
+
+from .mocking import MockLTI11Authenticator
 
 
 @pytest.mark.asyncio

--- a/ltiauthenticator/tests/test_lti13_authenticator.py
+++ b/ltiauthenticator/tests/test_lti13_authenticator.py
@@ -3,8 +3,7 @@ from unittest.mock import patch
 import pytest
 from tornado.web import RequestHandler
 
-from ltiauthenticator.lti13.auth import LTI13Authenticator
-from ltiauthenticator.lti13.auth import LTI13LaunchValidator
+from ltiauthenticator.lti13.auth import LTI13Authenticator, LTI13LaunchValidator
 
 
 @pytest.mark.asyncio

--- a/ltiauthenticator/tests/test_utils.py
+++ b/ltiauthenticator/tests/test_utils.py
@@ -2,8 +2,7 @@ from unittest.mock import Mock
 
 from tornado.web import RequestHandler
 
-from ltiauthenticator.utils import convert_request_to_dict
-from ltiauthenticator.utils import get_client_protocol
+from ltiauthenticator.utils import convert_request_to_dict, get_client_protocol
 
 
 def test_get_protocol_with_more_than_one_value():

--- a/ltiauthenticator/utils.py
+++ b/ltiauthenticator/utils.py
@@ -5,21 +5,19 @@ import re
 import time
 import urllib
 import uuid
-from typing import Any
-from typing import Dict
-from typing import List
+from typing import Any, Dict, List
 
 import jwt
 import pem
 from Crypto.PublicKey import RSA
 from jwcrypto.jwk import JWK
-from tornado.httpclient import AsyncHTTPClient
-from tornado.httpclient import HTTPClientError
+from tornado.httpclient import AsyncHTTPClient, HTTPClientError
 from tornado.web import RequestHandler
 
-from ltiauthenticator.lti13.constants import DEFAULT_ROLE_NAMES_FOR_INSTRUCTOR
-from ltiauthenticator.lti13.constants import DEFAULT_ROLE_NAMES_FOR_STUDENT
-
+from ltiauthenticator.lti13.constants import (
+    DEFAULT_ROLE_NAMES_FOR_INSTRUCTOR,
+    DEFAULT_ROLE_NAMES_FOR_STUDENT,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [tool.black]
 skip-string-normalization = true
-target_version = [
-    "py36",
-    "py37",
-    "py38",
-    "py39",
-]
+# target-version should be all supported versions
+target-version = ["py37", "py38", "py39", "py310"]
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-from setuptools import find_packages
-from setuptools import setup
-
+from setuptools import find_packages, setup
 
 setup(
     name="jupyterhub-ltiauthenticator",


### PR DESCRIPTION
This aligns this repo with a practices across the JupyterHub ecosystem.