### PR TITLE
breaking, maint: switch to using pyjwt v2

### DIFF
--- a/ltiauthenticator/lti13/validator.py
+++ b/ltiauthenticator/lti13/validator.py
@@ -144,11 +144,11 @@ class LTI13LaunchValidator(LoggingConfigurable):
           Decoded dictionary that represents the k/v's included with the JWT
         """
         if verify is False:
+            unverified_token = jwt.decode(id_token, options={"verify_signature": False})
             self.log.debug(
-                "JWK verification is off, returning token %s"
-                % jwt.decode(id_token, verify=False)
+                f"JWK verification is off, returning token {unverified_token}"
             )
-            return jwt.decode(id_token, verify=False)
+            return unverified_token
 
         jws = JWS.from_compact(id_token)
         self.log.debug("Retrieving matching jws %s" % jws)
@@ -164,7 +164,12 @@ class LTI13LaunchValidator(LoggingConfigurable):
             % (id_token, key_from_jwks, verify)
         )
 
-        return jwt.decode(id_token, key=key_from_jwks, verify=False, audience=audience)
+        return jwt.decode(
+            id_token,
+            key=key_from_jwks,
+            audience=audience,
+            options={"verify_signature": False},
+        )
 
     def is_deep_link_launch(
         self,

--- a/ltiauthenticator/tests/conftest.py
+++ b/ltiauthenticator/tests/conftest.py
@@ -497,7 +497,9 @@ def build_lti13_jwt_id_token() -> str:
         We can use the `make_lti13_resource_link_request` or `make_lti13_resource_link_request_privacy_enabled`
         fixture to create the json then call this method.
         """
-        encoded_jwt = jwt.encode(json_lti13_launch_request, "secret", algorithm="HS256")
+        encoded_jwt = jwt.encode(
+            json_lti13_launch_request, "secret", algorithm="HS256"
+        ).encode()
         return encoded_jwt
 
     return _make_lti13_jwt_id_token

--- a/ltiauthenticator/utils.py
+++ b/ltiauthenticator/utils.py
@@ -168,7 +168,7 @@ async def get_lms_access_token(
     params = {
         "grant_type": "client_credentials",
         "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-        "client_assertion": token.decode(),
+        "client_assertion": token,
         "scope": scope,
     }
     logger.debug("LTI 1.3 OAuth parameters are %s" % params)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "oauthenticator>=0.13.0",
         "pem>=20.1.0",
         "pycryptodome>=3.9.8",
-        "PyJWT>=1.7.1,<2",
+        "PyJWT>=2.4.0",
         "pyjwkest>=1.4.2",
     ],
     package_data={


### PR DESCRIPTION
@jgwerner this is my best attempt, but I can't verify this works and/or that I haven't broken something.

### Relevant reading: the [pyjwt changelog](https://pyjwt.readthedocs.io/en/stable/changelog.html#jwt-encode-return-type)

These breaking changes are changes that I've adjusted for in this PR.

- ![image](https://user-images.githubusercontent.com/3837114/171057515-29225f33-3cd5-450f-925f-a4527b751d09.png)
  
  Because of this change in `jwt.encode()`, I've removed a call to [`<bytes>.decode()`](https://docs.python.org/3/library/stdtypes.html#bytes.decode) variable set by calling `jwt.encode()`, as that is now part of the `jwt.encode()` function.

- ![image](https://user-images.githubusercontent.com/3837114/171057558-347e5259-257d-4c85-aaaa-e64d12e1e5fd.png)

  Because of this change in `jwt.decode()`, I've adjusted the arguments passed.

Closes #76.