### PR TITLE
LTI13: Make tool name & description configurable

### DIFF
--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -89,7 +89,7 @@ class LTI13Authenticator(OAuthenticator):
         Name of tool provided to the LMS when installed via the config URL.
 
         This is primarily used for display purposes.
-        """
+        """,
     )
 
     tool_description = Unicode(
@@ -99,7 +99,7 @@ class LTI13Authenticator(OAuthenticator):
         Description of tool provided to the LMS when installed via the config URL.
 
         This is primarily used for display purposes.
-        """
+        """,
     )
 
     def get_handlers(self, app: JupyterHub) -> List[BaseHandler]:

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict
+from typing import Dict, List
 
 from jupyterhub.app import JupyterHub
 from jupyterhub.auth import LocalAuthenticator
@@ -82,7 +82,27 @@ class LTI13Authenticator(OAuthenticator):
         """,
     )
 
-    def get_handlers(self, app: JupyterHub) -> BaseHandler:
+    tool_name = Unicode(
+        "JupyterHub",
+        config=True,
+        help="""
+        Name of tool provided to the LMS when installed via the config URL.
+
+        This is primarily used for display purposes.
+        """
+    )
+
+    tool_description = Unicode(
+        "Launch interactive Jupyter Notebooks with JupyterHub",
+        config=True,
+        help="""
+        Description of tool provided to the LMS when installed via the config URL.
+
+        This is primarily used for display purposes.
+        """
+    )
+
+    def get_handlers(self, app: JupyterHub) -> List[BaseHandler]:
         return [
             ("/lti13/config", LTI13ConfigHandler),
         ]

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -50,7 +50,7 @@ class LTI13ConfigHandler(BaseHandler):
         target_link_url = f"{protocol}://{self.request.host}"
         self.log.debug(f"Target link url is: {target_link_url}")
         keys = {
-            "title": "JupyterHub",
+            "title": self.authenticator.tool_name,
             "scopes": [
                 "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
                 "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
@@ -93,7 +93,7 @@ class LTI13ConfigHandler(BaseHandler):
                     "privacy_level": "public",
                 }
             ],
-            "description": "JupyterHub for interactive Jupyter notebook usage",
+            "description": self.authenticator.tool_description,
             "custom_fields": {
                 "email": "$Person.email.primary",
                 "lms_user_id": "$User.id",


### PR DESCRIPTION
This used to display information about the JupyterHub
in the LMS