### PR TITLE
Fix documentation for LTI1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ hub:
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
       authenticator_class: ltiauthenticator.LTIAuthenticator # LTI 1.1
-    LTI11Authenticator:
+    LTIAuthenticator:
       consumers: { "client-key": "client-secret" }
       username_key: "lis_person_contact_email_primary"
       config_icon: "https://my.static.assets/img/icon.jpg"


### PR DESCRIPTION
When using `ltiauthenticator.LTIAuthenticator` as the authenticator class, the respective section in the `config.yml` must be named `LTIAuthenticator` for the traitlet system to work.

Alternatively, one could instead change to
```yml
JupyterHub:
    authenticator_class: ltiauthenticator.lti11.auth.LTI11Authenticator
```
in the `config.yml` which would be analogous to the LTI1.3 configuration.