### PR TITLE
Fix for inconsistency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ pip install jupyterhub-ltiauthenticator
 
 ### LTI 1.1
 
+> **Note**: With release `1.1.0`, the import path of the authenticator class changed from `ltiauthenticator.LTIAuthenticator` to `ltiauthenticator.lti11.auth.LTI11Authenticator`. While the old path is still available to maintain backward compatibility, its use is deprecated and it will be removed in the next major release.
+
 #### Common Configuration Settings
 
 Due to the fact that LTI 1.1 is an open standard, Learning Management System (LMS) vendors that adhere to the LTI 1.1 standard utilize the same configuration settings when integrating with an external tool. Some of these settings are included in a configuration endpoint to facilitate the JupyterHub's as an external tool with your LMS.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ hub:
     # Additional documentation related to authentication and authorization available at
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
-      authenticator_class: ltiauthenticator.LTIAuthenticator # LTI 1.1
+      authenticator_class: ltiauthenticator.LTI11Authenticator # LTI 1.1
     LTIAuthenticator:
       consumers: { "client-key": "client-secret" }
       username_key: "lis_person_contact_email_primary"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ hub:
     # Additional documentation related to authentication and authorization available at
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
-      authenticator_class: ltiauthenticator.LTI11Authenticator # LTI 1.1
+      authenticator_class: ltiauthenticator.lti11.auth.LTI11Authenticator # LTI 1.1
     LTIAuthenticator:
       consumers: { "client-key": "client-secret" }
       username_key: "lis_person_contact_email_primary"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ hub:
     # https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html
     JupyterHub:
       authenticator_class: ltiauthenticator.lti11.auth.LTI11Authenticator # LTI 1.1
-    LTIAuthenticator:
+    LTI11Authenticator:
       consumers: { "client-key": "client-secret" }
       username_key: "lis_person_contact_email_primary"
       config_icon: "https://my.static.assets/img/icon.jpg"

--- a/examples/jupyterhub_config_lti11.py
+++ b/examples/jupyterhub_config_lti11.py
@@ -19,7 +19,7 @@ c.Authenticator.admin_users = {"admin"}
 c.Authenticator.enable_auth_state = True
 
 # Set the LTI 1.1 authenticator.
-c.JupyterHub.authenticator_class = "ltiauthenticator.LTIAuthenticator"
+c.JupyterHub.authenticator_class = "ltiauthenticator.lti11.auth.LTI11Authenticator"
 
 # Add the LTI 1.1 consumer key and shared secret. Note the use of
 # `LTI11Authenticator` vs the legacy `LTIAuthenticator`.


### PR DESCRIPTION
I found a small inconsistency in the README. AFAIK the authenticator class in the example at line 106 should be tiauthenticator.LTI11Authenticator, as in the note below the example.