### PR TITLE
LTI13: Add missing oauth handler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         # args are not passed, but see the config in pyproject.toml

--- a/ltiauthenticator/lti11/auth.py
+++ b/ltiauthenticator/lti11/auth.py
@@ -140,7 +140,6 @@ class LTI11Authenticator(Authenticator):
         self.log.debug(f"Launch url is: {launch_url}")
 
         if validator.validate_launch_request(launch_url, handler.request.headers, args):
-
             # raise an http error if the username_key is not in the request's arguments.
             if self.username_key not in args.keys():
                 self.log.warning(

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 from jupyterhub.app import JupyterHub
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.handlers import BaseHandler
+from jupyterhub.utils import url_path_join
 from oauthenticator.oauth2 import OAuthenticator
 from tornado.web import HTTPError
 from traitlets.config import List as TraitletsList
@@ -115,9 +116,14 @@ class LTI13Authenticator(OAuthenticator):
         """,
     )
 
+    def login_url(self, base_url):
+        return url_path_join(base_url, "lti13", "oauth_login")
+
     def get_handlers(self, app: JupyterHub) -> List[BaseHandler]:
         return [
-            ("/lti13/config", LTI13ConfigHandler),
+            (r"/lti13/oauth_login", self.login_handler),
+            (r"/lti13/oauth_callback", self.callback_handler),
+            (r"/lti13/config", LTI13ConfigHandler),
         ]
 
     async def authenticate(

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -119,11 +119,17 @@ class LTI13Authenticator(OAuthenticator):
     def login_url(self, base_url):
         return url_path_join(base_url, "lti13", "oauth_login")
 
+    def callback_url(self, base_url):
+        return url_path_join(base_url, "lti13", "oauth_callback")
+
+    def config_url(self, base_url):
+        return url_path_join(base_url, "lti13", "config")
+
     def get_handlers(self, app: JupyterHub) -> List[BaseHandler]:
         return [
-            (r"/lti13/oauth_login", self.login_handler),
-            (r"/lti13/oauth_callback", self.callback_handler),
-            (r"/lti13/config", LTI13ConfigHandler),
+            (self.login_url(""), self.login_handler),
+            (self.callback_url(""), self.callback_handler),
+            (self.config_url(""), LTI13ConfigHandler),
         ]
 
     async def authenticate(

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -125,6 +125,9 @@ class LTI13Authenticator(OAuthenticator):
     def config_url(self, base_url):
         return url_path_join(base_url, "lti13", "config")
 
+    def jwks_url(self, base_url):
+        return url_path_join(base_url, "lti13", "jwks")
+
     def get_handlers(self, app: JupyterHub) -> List[BaseHandler]:
         return [
             (self.login_url(""), self.login_handler),

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -122,7 +122,7 @@ class LTI13Authenticator(OAuthenticator):
     def callback_url(self, base_url):
         return url_path_join(base_url, "lti13", "oauth_callback")
 
-    def config_url(self, base_url):
+    def config_json_url(self, base_url):
         return url_path_join(base_url, "lti13", "config")
 
     def jwks_url(self, base_url):
@@ -132,7 +132,7 @@ class LTI13Authenticator(OAuthenticator):
         return [
             (self.login_url(""), self.login_handler),
             (self.callback_url(""), self.callback_handler),
-            (self.config_url(""), LTI13ConfigHandler),
+            (self.config_json_url(""), LTI13ConfigHandler),
         ]
 
     async def authenticate(

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -254,6 +254,9 @@ class LTI13LoginHandler(OAuthLoginHandler):
             extra_params={"state": state},
         )
 
+    # GET requests are also allowed by the OpenID Conect launch flow:
+    # https://www.imsglobal.org/spec/security/v1p0/#fig_oidcflow
+    #
     get = post
 
 

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -227,7 +227,7 @@ class LTI13LoginHandler(OAuthLoginHandler):
         redirect_uri = "{proto}://{host}{path}".format(
             proto=self.request.protocol,
             host=self.request.host,
-            path=url_path_join(self.hub.server.base_url, "/lti13/oauth_callback"),
+            path=self.authenticator.callback_url(self.hub.server.base_url),
         )
         self.log.debug(f"redirect_uri is: {redirect_uri}")
 
@@ -249,6 +249,8 @@ class LTI13LoginHandler(OAuthLoginHandler):
             state=state,
             extra_params={"state": state},
         )
+
+    get = post
 
 
 class LTI13CallbackHandler(OAuthCallbackHandler):

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -9,17 +9,25 @@ from urllib.parse import quote, unquote, urlparse
 import pem
 from Crypto.PublicKey import RSA
 from jupyterhub.handlers import BaseHandler
+from jupyterhub.utils import url_path_join
 from oauthenticator.oauth2 import (
     OAuthCallbackHandler,
     OAuthLoginHandler,
     _serialize_state,
-    guess_callback_uri,
 )
 from tornado.httputil import url_concat
 from tornado.web import HTTPError, RequestHandler
 
 from ..utils import convert_request_to_dict, get_client_protocol, get_jwk
 from .validator import LTI13LaunchValidator
+
+
+def guess_callback_uri(protocol, host, hub_server_url):
+    return "{proto}://{host}{path}".format(
+        proto=protocol,
+        host=host,
+        path=url_path_join(hub_server_url, "/lti13/oauth_callback"),
+    )
 
 
 class LTI13ConfigHandler(BaseHandler):
@@ -224,7 +232,7 @@ class LTI13LoginHandler(OAuthLoginHandler):
         client_id = args["client_id"]
         self.log.debug(f"client_id is {client_id}")
         redirect_uri = guess_callback_uri(
-            "https", self.request.host, self.hub.server.base_url
+            self.request.protocol, self.request.host, self.hub.server.base_url
         )
         self.log.info(f"redirect_uri: {redirect_uri}")
         state = self.get_state()

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -98,9 +98,13 @@ class LTI13ConfigHandler(BaseHandler):
                 "email": "$Person.email.primary",
                 "lms_user_id": "$User.id",
             },
-            "public_jwk_url": f"{target_link_url}{self.base_url}hub/lti13/jwks",
+            "public_jwk_url": self.authenticator.jwks_url(
+                url_path_join(target_link_url, self.hub.server.base_url)
+            ),
             "target_link_uri": target_link_url,
-            "oidc_initiation_url": f"{target_link_url}{self.base_url}hub/oauth_login",
+            "oidc_initiation_url": self.authenticator.login_url(
+                url_path_join(target_link_url, self.hub.server.base_url)
+            ),
         }
         self.write(json.dumps(keys))
 

--- a/tests/lti11/test_lti11_authenticator.py
+++ b/tests/lti11/test_lti11_authenticator.py
@@ -20,7 +20,6 @@ async def test_authenticator_uses_lti11validator(
     with patch.object(
         LTI11LaunchValidator, "validate_launch_request", return_value=True
     ) as mock_validator:
-
         authenticator = MockLTI11Authenticator()
         authenticator.username_key = "custom_canvas_user_id"
         handler = Mock(spec=RequestHandler)

--- a/tests/lti13/mocking.py
+++ b/tests/lti13/mocking.py
@@ -1,8 +1,4 @@
-from jupyterhub.app import JupyterHub
-from jupyterhub.handlers import BaseHandler
-
 from ltiauthenticator.lti13.auth import LTI13Authenticator
-from ltiauthenticator.lti13.handlers import LTI13ConfigHandler
 
 
 class MockLTI13Authenticator(LTI13Authenticator):
@@ -20,8 +16,3 @@ class MockLTI13Authenticator(LTI13Authenticator):
     authorize_url = "https://my.platform.domain/api/lti/authorize_redirect"
     endpoint = "https://my.platform.domain"
     token_url = "https://my.platform.domain/login/oauth2/token"
-
-    def get_handlers(self, app: JupyterHub) -> BaseHandler:
-        return [
-            (f"{self.config_url}", LTI13ConfigHandler),
-        ]

--- a/tests/lti13/test_lti13_handlers.py
+++ b/tests/lti13/test_lti13_handlers.py
@@ -5,4 +5,7 @@ async def test_lti_13_handler_paths(app):
     """Test if all handlers are correctly set with the LTI13Authenticator."""
     auth = MockLTI13Authenticator()
     handlers = auth.get_handlers(app)
-    assert handlers[0][0] == "/lti13/config"
+    handler_paths = [route[0] for route in handlers]
+    assert "/lti13/config" in handler_paths
+    assert "/lti13/oauth_login" in handler_paths
+    assert "/lti13/oauth_callback" in handler_paths

--- a/tests/lti13/test_lti13_handlers.py
+++ b/tests/lti13/test_lti13_handlers.py
@@ -6,6 +6,6 @@ async def test_lti_13_handler_paths(app):
     auth = MockLTI13Authenticator()
     handlers = auth.get_handlers(app)
     handler_paths = [route[0] for route in handlers]
-    assert "/lti13/config" in handler_paths
-    assert "/lti13/oauth_login" in handler_paths
-    assert "/lti13/oauth_callback" in handler_paths
+    assert "lti13/config" in handler_paths
+    assert "lti13/oauth_login" in handler_paths
+    assert "lti13/oauth_callback" in handler_paths


### PR DESCRIPTION
Currently, there is no route set to the OAuth2 login and callback handler in the LTI13Authenticator. This renders this authenticator essentially useless.

This PR adds routes to the respective handler. The paths are prefixed by `lti13` to avoid potential conflicts when using multiple authenticators become possible.

A backport of this fix for the most recent release would be great! If desired, I can open another PR for that.

Ref: #123 