### PR TITLE
Relax resource link launch request message requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/pycqa/isort
-    rev: v5.11.3
+    rev: 5.12.0
     hooks:
       - id: isort
         # args are not passed, but see the config in pyproject.toml

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -7,7 +7,8 @@ from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.handlers import BaseHandler
 from oauthenticator.oauth2 import OAuthenticator
 from tornado.web import HTTPError
-from traitlets.config import Unicode, List as TraitletsList
+from traitlets.config import List as TraitletsList
+from traitlets.config import Unicode
 
 from .handlers import (
     LTI13CallbackHandler,

--- a/ltiauthenticator/lti13/constants.py
+++ b/ltiauthenticator/lti13/constants.py
@@ -122,13 +122,6 @@ LTI13_LIS_CLAIMS = {
     },
 }
 
-# Required claims for ResourceLinkRequest
-# For this setup to work properly, some optional claims are required.
-# LTI13_RESOURCE_LINK_REQUIRED_CLAIMS = {
-#     **LTI13_RESOURCE_LINK_REQUIRED_CLAIMS,
-#     **LTI13_RESOURCE_LINK_OPTIONAL_CLAIMS,
-# }
-
 # Required and optional resource link claims
 LTI13_RESOURCE_LINKS = {
     **LTI13_RESOURCE_LINK_REQUIRED_CLAIMS[
@@ -138,11 +131,6 @@ LTI13_RESOURCE_LINKS = {
         "https://purl.imsglobal.org/spec/lti/claim/resource_link"
     ],
 }
-
-# Updates required claims with optional claims
-# LTI13_RESOURCE_LINK_REQUIRED_CLAIMS[
-#     "https://purl.imsglobal.org/spec/lti/claim/resource_link"
-# ].update(LTI13_RESOURCE_LINKS)
 
 # Required claims for DeepLinkingRequest
 LTI13_DEEP_LINKING_REQUIRED_CLAIMS = {

--- a/ltiauthenticator/lti13/constants.py
+++ b/ltiauthenticator/lti13/constants.py
@@ -124,10 +124,10 @@ LTI13_LIS_CLAIMS = {
 
 # Required claims for ResourceLinkRequest
 # For this setup to work properly, some optional claims are required.
-LTI13_RESOURCE_LINK_REQUIRED_CLAIMS = {
-    **LTI13_RESOURCE_LINK_REQUIRED_CLAIMS,
-    **LTI13_RESOURCE_LINK_OPTIONAL_CLAIMS,
-}
+# LTI13_RESOURCE_LINK_REQUIRED_CLAIMS = {
+#     **LTI13_RESOURCE_LINK_REQUIRED_CLAIMS,
+#     **LTI13_RESOURCE_LINK_OPTIONAL_CLAIMS,
+# }
 
 # Required and optional resource link claims
 LTI13_RESOURCE_LINKS = {
@@ -140,9 +140,9 @@ LTI13_RESOURCE_LINKS = {
 }
 
 # Updates required claims with optional claims
-LTI13_RESOURCE_LINK_REQUIRED_CLAIMS[
-    "https://purl.imsglobal.org/spec/lti/claim/resource_link"
-].update(LTI13_RESOURCE_LINKS)
+# LTI13_RESOURCE_LINK_REQUIRED_CLAIMS[
+#     "https://purl.imsglobal.org/spec/lti/claim/resource_link"
+# ].update(LTI13_RESOURCE_LINKS)
 
 # Required claims for DeepLinkingRequest
 LTI13_DEEP_LINKING_REQUIRED_CLAIMS = {

--- a/ltiauthenticator/lti13/constants.py
+++ b/ltiauthenticator/lti13/constants.py
@@ -71,13 +71,13 @@ LTI13_GENERAL_OPTIONAL_CLAIMS = {
     },
     # user identity claims. sub (subject) is added to optional list to support anonymous
     # launches.
+    "sub": "",
     "aud": "",
     # "azp": "",
     "exp": None,
     "iat": None,
     "iss": "",
     "nonce": "",
-    "sub": "",
     "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
         "guid": "",
         "name": "",

--- a/ltiauthenticator/lti13/validator.py
+++ b/ltiauthenticator/lti13/validator.py
@@ -100,7 +100,9 @@ class LTI13LaunchValidator(LoggingConfigurable):
                 "https://purl.imsglobal.org/spec/lti/claim/message_type"
             ]
         ):
-            raise HTTPError(400, f"Incorrect value {message_type} for version claim")
+            raise HTTPError(
+                400, f"Incorrect value {message_type} for message_type claim"
+            )
 
     def validate_launch_request(self, jwt_decoded: Dict[str, Any]) -> None:
         """

--- a/tests/lti13/conftest.py
+++ b/tests/lti13/conftest.py
@@ -57,7 +57,34 @@ def launch_req_jwt():
 
 
 @pytest.fixture
-def launch_req_jwt_decoded() -> Dict[str, str]:
+def minimal_launch_req_jwt_decoded() -> Dict[str, object]:
+    """
+    Returns valid json after decoding JSON Web Token (JWT) for resource link launch (core).
+
+    Only contains message claims flagged as required by the LTI 1.3 specs.
+    https://www.imsglobal.org/spec/lti/v1p3#required-message-claims
+    """
+    jwt_decoded = {
+        "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
+        "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+        "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "deployment1",
+        "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": "https://lti-ri.imsglobal.org/lti/tools/3356/launches",
+        "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
+            "id": "74256",
+        },
+        "https://purl.imsglobal.org/spec/lti/claim/roles": [],
+        # Required OAuth2 claims
+        # https://www.imsglobal.org/spec/security/v1p0/#using-oauth-2-0-client-credentials-grant
+        "iss": "https://github.com/jupyterhub/ltiauthenticator",
+        "aud": "client1",
+        "iat": 1668266555,
+        "exp": 1668266855,
+    }
+    return jwt_decoded
+
+
+@pytest.fixture
+def launch_req_jwt_decoded(minimal_launch_req_jwt_decoded) -> Dict[str, str]:
     """
     Returns a decoded JSON Web Token (JWT) for the authenticate request
     (resource link launch).
@@ -69,76 +96,69 @@ def launch_req_jwt_decoded() -> Dict[str, str]:
     # This example data is provided via:
     # https://lti-ri.imsglobal.org/platforms/3691/resource_links/74256?nonce=ebc9ab705d0bab3e9dc6&redirect_uri=https%3A%2F%2Flti-ri.imsglobal.org%2Flti%2Ftools%2F3356%2Flaunches&tool_state=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjNyNlRqNW9JbWw2cW9VcnBIcWh1NjJsY0N1OW9qTzNKYXAyTFpuTnIybWsiLCJ0eXAiOiJKV1QifQ.eyJ0b29sX2lkIjozMzU2LCJzdGF0ZV9ub25jZSI6ImViYzlhYjcwNWQwYmFiM2U5ZGM2IiwicGFyYW1zIjp7InV0ZjgiOiLinJMiLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vanVweXRlcmh1Yi9sdGlhdXRoZW50aWNhdG9yIiwibG9naW5faGludCI6IjU0NDU2NCIsInRhcmdldF9saW5rX3VyaSI6Imh0dHBzOi8vbHRpLXJpLmltc2dsb2JhbC5vcmcvbHRpL3Rvb2xzLzMzNTYvbGF1bmNoZXMiLCJsdGlfbWVzc2FnZV9oaW50IjoiNzQyNTYiLCJsdGlfZGVwbG95bWVudF9pZCI6ImRlcGxveW1lbnQxIiwiY2xpZW50X2lkIjoiY2xpZW50MSIsImNvbW1pdCI6IlBvc3QgcmVxdWVzdCIsImNvbnRyb2xsZXIiOiJsdGkvbG9naW5faW5pdGlhdGlvbnMiLCJhY3Rpb24iOiJjcmVhdGUiLCJ0b29sX2lkIjoiMzM1NiJ9LCJpc3MiOiJqdXB5dGVyaHViLWx0aWF1dGhlbnRpY2F0b3ItdGVzdC10b29sIiwic3ViIjoiY2xpZW50MSIsImF1ZCI6Imh0dHBzOi8vbHRpLXJpLmltc2dsb2JhbC5vcmcvcGxhdGZvcm1zLzM2OTEvYWNjZXNzX3Rva2VucyIsImlhdCI6MTY2ODI2NjU1MCwiZXhwIjoxNjY4MjY2ODUwLCJqdGkiOiIyMmM1NjU1ZTNiMjFjNjdjOWYwNyJ9.VJa5KQEjekM7vmmgCLVUN1c6XBv-B-2nkvKzki-8m6XpZ4F2eBiwG2518wXKAEsttHDmWRnjd_d5DU1sOG3RP8XcybGe578o7bY2iSHkwrqlykBw5pvlg3MPpdY9VsdVL_SUTY5HMq8M8A2krfR82giI1Iy0a475d9d4rtZ7VLTCCxMadYIMo0SDZCmhHsF2QtfbYT3bsFh2LmrhsPEun80eLNYxwkrRLS633sAkNWmekhRqAUsPMmqocDUwxRxsDbbvmHpBRUO3cl8Dqbaxz52TVQtLl6rEi9gux4D83IHehC0Q5HKFU04WhXNo_XdHU_0IK7tXYw9uMw6CvKKhWg&user_id=544564
     #
-    jwt_decoded = {
-        "https://purl.imsglobal.org/spec/lti/claim/message_type": "LtiResourceLinkRequest",
-        "https://purl.imsglobal.org/spec/lti/claim/roles": [
-            "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
-            "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
-            "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor",
-        ],
-        "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
-            "a62c52c02ba262003f5e"
-        ],
-        "https://purl.imsglobal.org/spec/lti/claim/resource_link": {
-            "id": "74256",
-            "title": "link1",
-            "description": "",
-        },
-        "https://purl.imsglobal.org/spec/lti/claim/context": {
-            "id": "54536",
-            "label": "course1",
-            "title": "course1",
-            "type": [""],
-        },
-        "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
-            "name": "jupyterhub-ltiauthenticator-test-platform",
-            "contact_email": "",
-            "description": "",
-            "url": "",
-            "product_family_code": "",
-            "version": "1.0",
-            "guid": "3691",
-        },
-        "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": {
-            "scope": [
-                "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
-                "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
-                "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+    jwt_decoded = minimal_launch_req_jwt_decoded
+    jwt_decoded["https://purl.imsglobal.org/spec/lti/claim/roles"] = [
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor",
+    ]
+    jwt_decoded["https://purl.imsglobal.org/spec/lti/claim/resource_link"].update(
+        {"title": "link1", "description": ""}
+    )
+    jwt_decoded.update(
+        {
+            "https://purl.imsglobal.org/spec/lti/claim/role_scope_mentor": [
+                "a62c52c02ba262003f5e"
             ],
-            "lineitems": "https://lti-ri.imsglobal.org/platforms/3691/contexts/54536/line_items",
-        },
-        "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice": {
-            "context_memberships_url": "https://lti-ri.imsglobal.org/platforms/3691/contexts/54536/memberships",
-            "service_versions": ["2.0"],
-        },
-        "https://purl.imsglobal.org/spec/lti-ces/claim/caliper-endpoint-service": {
-            "scopes": ["https://purl.imsglobal.org/spec/lti-ces/v1p0/scope/send"],
-            "caliper_endpoint_url": "https://lti-ri.imsglobal.org/platforms/3691/sensors",
-            "caliper_federated_session_id": "urn:uuid:94c3a94ca70647d08e7c",
-        },
-        "iss": "https://github.com/jupyterhub/ltiauthenticator",
-        "aud": "client1",
-        "iat": 1668266555,
-        "exp": 1668266855,
-        "sub": "1ace7501877e6a429fca",
-        "nonce": "ebc9ab705d0bab3e9dc6",
-        "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
-        "locale": "en-US",
-        "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
-            "document_target": "iframe",
-            "height": 320,
-            "width": 240,
-            "return_url": "https://lti-ri.imsglobal.org/platforms/3691/returns",
-        },
-        "https://www.example.com/extension": {
-            "color": "violet",
-        },
-        "https://purl.imsglobal.org/spec/lti/claim/custom": {
-            "myCustomValue": "123",
-        },
-        "https://purl.imsglobal.org/spec/lti/claim/deployment_id": "deployment1",
-        "https://purl.imsglobal.org/spec/lti/claim/target_link_uri": "https://lti-ri.imsglobal.org/lti/tools/3356/launches",
-    }
+            "https://purl.imsglobal.org/spec/lti/claim/context": {
+                "id": "54536",
+                "label": "course1",
+                "title": "course1",
+                "type": [""],
+            },
+            "https://purl.imsglobal.org/spec/lti/claim/tool_platform": {
+                "name": "jupyterhub-ltiauthenticator-test-platform",
+                "contact_email": "",
+                "description": "",
+                "url": "",
+                "product_family_code": "",
+                "version": "1.0",
+                "guid": "3691",
+            },
+            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint": {
+                "scope": [
+                    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+                    "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+                    "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+                ],
+                "lineitems": "https://lti-ri.imsglobal.org/platforms/3691/contexts/54536/line_items",
+            },
+            "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice": {
+                "context_memberships_url": "https://lti-ri.imsglobal.org/platforms/3691/contexts/54536/memberships",
+                "service_versions": ["2.0"],
+            },
+            "https://purl.imsglobal.org/spec/lti-ces/claim/caliper-endpoint-service": {
+                "scopes": ["https://purl.imsglobal.org/spec/lti-ces/v1p0/scope/send"],
+                "caliper_endpoint_url": "https://lti-ri.imsglobal.org/platforms/3691/sensors",
+                "caliper_federated_session_id": "urn:uuid:94c3a94ca70647d08e7c",
+            },
+            "sub": "1ace7501877e6a429fca",
+            "nonce": "ebc9ab705d0bab3e9dc6",
+            "locale": "en-US",
+            "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+                "document_target": "iframe",
+                "height": 320,
+                "width": 240,
+                "return_url": "https://lti-ri.imsglobal.org/platforms/3691/returns",
+            },
+            "https://www.example.com/extension": {
+                "color": "violet",
+            },
+            "https://purl.imsglobal.org/spec/lti/claim/custom": {
+                "myCustomValue": "123",
+            },
+        }
+    )
     return jwt_decoded
 
 

--- a/tests/lti13/test_lti13_validator.py
+++ b/tests/lti13/test_lti13_validator.py
@@ -34,6 +34,18 @@ def test_validate_verify_and_decode_jwt(launch_req_jwt, launch_req_jwt_decoded):
 
 # Tests of validate_launch_request()
 # -------------------------------------------------------------------------------
+def test_validate_minimal_launch_request(minimal_launch_req_jwt_decoded):
+    """
+    Is the JWT valid if it contains only the claims required by the LTI 1.3 specs?
+
+    Ref: https://www.imsglobal.org/spec/lti/v1p3#required-message-claims
+    """
+    validator = LTI13LaunchValidator()
+    validator.validate_launch_request(minimal_launch_req_jwt_decoded)
+
+
+# Tests of validate_launch_request()
+# -------------------------------------------------------------------------------
 def test_validate_launch_request_empty_roles(launch_req_jwt_decoded):
     validator = LTI13LaunchValidator()
     launch_req_jwt_decoded["https://purl.imsglobal.org/spec/lti/claim/roles"] = ""


### PR DESCRIPTION
The validation of LTI 1.3 resource link launch requests is too strict. Actually all claims, required and optional, are currently mandatory. This strongly limits the usability of the authenticator since many LMS platforms might not or cannot provide all optional claims.

This PR limits the claims required for a valid launch request message to the [minimum defined by the LTI 1.3 specs](https://www.imsglobal.org/spec/lti/v1p3#required-message-claims).