### PR TITLE
Silence OAuthlib deprication warnings

### DIFF
--- a/ltiauthenticator/lti11/validator.py
+++ b/ltiauthenticator/lti11/validator.py
@@ -2,7 +2,7 @@ import time
 from collections import OrderedDict
 from typing import Any, Dict
 
-from oauthlib.oauth1.rfc5849 import signature
+from oauthlib.oauth1.rfc5849 import Client, signature
 from tornado.web import HTTPError
 from traitlets.config import LoggingConfigurable
 
@@ -117,7 +117,12 @@ class LTI11LaunchValidator(LoggingConfigurable):
             ),
         )
         consumer_secret = self.consumers[args["oauth_consumer_key"]]
-        sign = signature.sign_hmac_sha1(base_string, consumer_secret, None)
+        sign = signature.sign_hmac_sha1_with_client(
+            base_string,
+            Client(
+                client_key=args["oauth_consumer_key"], client_secret=consumer_secret
+            ),
+        )
         is_valid = signature.safe_string_equals(sign, args["oauth_signature"])
         self.log.debug(f"signature in request: {args['oauth_signature']}")
         self.log.debug(f"calculated signature: {sign}")

--- a/tests/lti11/conftest.py
+++ b/tests/lti11/conftest.py
@@ -5,7 +5,7 @@ from typing import Dict
 from unittest.mock import Mock
 
 import pytest
-from oauthlib.oauth1.rfc5849 import signature
+from oauthlib.oauth1.rfc5849 import Client, signature
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application, RequestHandler
 
@@ -115,8 +115,12 @@ def get_launch_args():
             ),
         )
 
-        args["oauth_signature"] = signature.sign_hmac_sha1(
-            base_string, oauth_consumer_secret, None
+        client = Client(
+            client_key=oauth_consumer_key, client_secret=oauth_consumer_secret
+        )
+
+        args["oauth_signature"] = signature.sign_hmac_sha1_with_client(
+            base_string, client
         )
         return args
 


### PR DESCRIPTION
`oauthlib.oauth1.rfc5849.signature.sign_hmac_sha1` has been depricated. This function has been replaced by `oauthlib.oauth1.rfc5849.signature.sign_hmac_sha1_with_client`, which has slightly different signature.