### PR TITLE
Add local dev deployment for LTI 1.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         # args are not passed, but see the config in pyproject.toml

--- a/dev/Dockerfile.jupyterhub
+++ b/dev/Dockerfile.jupyterhub
@@ -1,0 +1,14 @@
+ARG JUPYTERHUB_VERSION
+FROM jupyterhub/jupyterhub:$JUPYTERHUB_VERSION
+
+RUN python3 -m pip install --no-cache-dir \
+        dockerspawner==12.*
+
+COPY . /ltiauthenticator
+
+# Install ltiauthenticator
+RUN python3 -m pip install --no-cache-dir \
+        /ltiauthenticator
+# 'jupyterhub-ltiauthenticator @ git+https://github.com/martinclaus/ltiauthenticator@test-add-handler'
+
+CMD ["jupyterhub", "-f", "/srv/jupyterhub/jupyterhub_config.py"]

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,61 @@
+# Development Deployment for LTI 1.3
+This is a docker compose development deployment for Jupyterhub with ltiauthenticator using LTI 1.3.
+It allows to test the [ltiauthenticator](https://github.com/jupyterhub/ltiauthenticator) package against the [LTI 1.3 DevKit](https://github.com/oat-sa/devkit-lti1p3) which is distributed separately.
+This document provides information on how to set up and run both the dev deployment and the DevKit for local testing purposes.
+
+## ltiauthenticator dev deployment
+You need `docker` and `docker-compose` available on your local development machine.
+
+### Build and run
+Clone this repository to your local machine, if not already done.
+```sh
+git clone https://github.com/jupyterhub/ltiauthenticator.git
+```
+
+Swtich to the `dev` subfolder and build the docker stack
+```sh
+cd dev
+docker-compose build
+```
+This will pull a Jupyterhub image and installs your local development version of the `ltiauthenticator` package into it.
+Then run the Jupyterhub:
+```sh
+docker compose up -d
+```
+This will make your hub available at http://dev-jh-lti.localhost:8000/.
+
+To update the dev deployment with the most recent code changes, run both commands again.
+
+### Configure LTI13Authenticator
+The relevant configuration for the LTI 1.3 authenticator within Jupyterhub can be set via environment variables in the [`docker-compose.yml`](./docker-compose.yml).
+Those variables are prefixed by `LTI13`.
+
+After applying changes to the configuration, refresh the compose project.
+```sh
+docker compose up -d
+```
+
+## LTI 1.3 DevKit deployment
+
+### Build and run
+Clone the repository from Github to some location outside your project folder
+```sh
+git clone --depth 1 --branch 2.5.2 https://github.com/oat-sa/devkit-lti1p3.git
+```
+Switch to the newly created folder and build and run the docker stack
+```sh
+docker compose up -d
+```
+Then, install the required PHP dependencies
+```
+docker run --rm --interactive --tty \
+  --volume $PWD:/app \
+  composer install
+```
+After installation, the development kit is available on http://devkit-lti1p3.localhost
+
+### Link to Hub deployment
+To link the Jupyterhub and LTI platform deployments, add the LTI config to the DevKit deployment
+```sh
+cp <PATH-TO-LTIAUTHENTICATOR-PROJECT>/dev/devkit-lti1p3.yaml <PATH-TO-LTI-DEVKIT-DEPLOYMENT>/config/packages/lti1p3.yaml
+```

--- a/dev/devkit-lti1p3.yaml
+++ b/dev/devkit-lti1p3.yaml
@@ -1,0 +1,46 @@
+lti1p3:
+    scopes:
+        - 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly'
+        - 'https://purl.imsglobal.org/spec/lti-bo/scope/basicoutcome'
+        - 'https://purl.imsglobal.org/spec/lti-ap/scope/control.all'
+        - 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem'
+        - 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly'
+        - 'https://purl.imsglobal.org/spec/lti-ags/scope/score'
+        - 'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly'
+    key_chains:
+        platformKey:
+            key_set_name: "platformSet"
+            public_key: "file://%kernel.project_dir%/config/keys/public.key"
+            private_key: "file://%kernel.project_dir%/config/keys/private.key"
+            private_key_passphrase: ~
+        toolKey:
+            key_set_name: "toolSet"
+            public_key: "file://%kernel.project_dir%/config/keys/public.key"
+            private_key: "file://%kernel.project_dir%/config/keys/private.key"
+            private_key_passphrase: ~
+    platforms:
+        devkitPlatform:
+            name: "LTI 1.3 DevKit (as platform)"
+            audience: "%application_host%/platform"
+            oidc_authentication_url: "%application_host%/lti1p3/oidc/authentication"
+            oauth2_access_token_url: "%application_host%/lti1p3/auth/platformKey/token"
+    tools:
+        jupyterHub:
+            name: "JupyterHub LTI 1.3 Authenticator"
+            audience: "http://dev-jh-lti.localhost:8000/"
+            oidc_initiation_url: "http://dev-jh-lti.localhost:8000/hub/lti13/oauth_login"
+            launch_url: "http://dev-jh-lti.localhost:8000/hub/lti13/oauth_login"
+            deep_linking_url: "%application_host%/tool/launch"
+    registrations:
+        devkit:
+            client_id: "lti13authenticator-dev"
+            platform: "devkitPlatform"
+            tool: "jupyterHub"
+            deployment_ids:
+                - "deploymentId1"
+                - "deploymentId2"
+            platform_key_chain: "platformKey"
+            tool_key_chain: "toolKey"
+            platform_jwks_url: "%application_host%/lti1p3/.well-known/jwks/platformSet.json"
+            tool_jwks_url: "%application_host%/lti1p3/.well-known/jwks/toolSet.json"
+            order: 1

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,67 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# JupyterHub docker-compose configuration file
+version: "3"
+
+services:
+  hub:
+    build:
+      context: ../
+      dockerfile: dev/Dockerfile.jupyterhub
+      args:
+        JUPYTERHUB_VERSION: 3.1.0
+    restart: always
+    image: jupyterhub
+    container_name: jupyterhub
+    networks:
+      jupyterhub-network:
+        aliases:
+          - dev-jh-lti.localhost
+    volumes:
+      # The JupyterHub configuration file
+      - "./jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro"
+      # Bind Docker socket on the host so we can connect to the daemon from
+      # within the container
+      - "/var/run/docker.sock:/var/run/docker.sock:rw"
+      # Bind Docker volume on host for JupyterHub database and cookie secrets
+      - "jupyterhub-data:/data"
+    ports:
+      - "8000:8000"
+    environment:
+      # User name claim containing a string which will be used by Jupyterhub as user name.
+      # Must be a unique identifyer of the user on the LTI Platform (LMS).
+      LTI13_USERNAME_KEY: sub
+      # The LTI 1.3 authorization url. The url of the platforms (LMS) endpoint for OAuth2
+      # authentication
+      LTI13_AUTHORIZE_URL: http://devkit-lti1p3.localhost/lti/auth
+      # The external tool's client id as represented within the platform (LMS)
+      # Note: the client id is not required by some LMS's for authentication.
+      # Only required, if the JupyterHub is suppose to send back information to the LMS
+      LTI13_CLIENT_ID: 2t1ZSR8uvaoVH8T
+      # The JWKS endpoint of the platform (LMS).
+      # Currently not used since JWK verification is off (hard coded).
+      LTI13_ENDPOINT: http://devkit-lti1p3.localhost/lti/keys
+      # The LTI 1.3 token url used to validate JWT signatures
+      LTI13_TOKEN_URL: http://devkit-lti1p3.localhost/lti/token
+
+      # This username will be a JupyterHub admin
+      JUPYTERHUB_ADMIN: admin
+      # All containers will join this network
+      DOCKER_NETWORK_NAME: jupyterhub-network
+      # JupyterHub will spawn this Notebook image for users
+      DOCKER_NOTEBOOK_IMAGE: jupyter/minimal-notebook:latest
+      # Notebook directory inside user image
+      DOCKER_NOTEBOOK_DIR: /home/jovyan/work
+      # Using this run command
+      DOCKER_SPAWN_CMD: start-singleuser.sh
+    command: >
+      jupyterhub -f /srv/jupyterhub/jupyterhub_config.py
+
+volumes:
+  jupyterhub-data:
+
+
+networks:
+  jupyterhub-network:
+    name: jupyterhub-network

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -34,16 +34,15 @@ services:
       LTI13_USERNAME_KEY: sub
       # The LTI 1.3 authorization url. The url of the platforms (LMS) endpoint for OAuth2
       # authentication
-      LTI13_AUTHORIZE_URL: http://devkit-lti1p3.localhost/lti/auth
+      LTI13_AUTHORIZE_URL: http://devkit-lti1p3.localhost/lti1p3/oidc/authentication
       # The external tool's client id as represented within the platform (LMS)
       # Note: the client id is not required by some LMS's for authentication.
       # Only required, if the JupyterHub is suppose to send back information to the LMS
-      LTI13_CLIENT_ID: 2t1ZSR8uvaoVH8T
+      LTI13_CLIENT_ID: lti13authenticator-dev
       # The JWKS endpoint of the platform (LMS).
-      # Currently not used since JWK verification is off (hard coded).
-      LTI13_ENDPOINT: http://devkit-lti1p3.localhost/lti/keys
+      LTI13_ENDPOINT: http://devkit-lti1p3.localhost/lti1p3/.well-known/jwks/platformSet.json
       # The LTI 1.3 token url used to validate JWT signatures
-      LTI13_TOKEN_URL: http://devkit-lti1p3.localhost/lti/token
+      LTI13_TOKEN_URL: http://devkit-lti1p3.localhost/lti1p3/auth/platformKey/token
 
       # This username will be a JupyterHub admin
       JUPYTERHUB_ADMIN: admin

--- a/dev/jupyterhub_config.py
+++ b/dev/jupyterhub_config.py
@@ -6,6 +6,8 @@ import os
 
 c = get_config()
 
+c.Application.log_level = "DEBUG"
+
 # We rely on environment variables to configure JupyterHub so that we
 # avoid having to rebuild the JupyterHub container every time we change a
 # configuration parameter.

--- a/dev/jupyterhub_config.py
+++ b/dev/jupyterhub_config.py
@@ -30,7 +30,6 @@ c.LTI13Authenticator.authorize_url = os.environ["LTI13_AUTHORIZE_URL"]
 c.LTI13Authenticator.client_id = os.environ.get("LTI13_CLIENT_ID", "")
 
 # The JWKS endpoint of the platform (LMS).
-# Currently not used since JWK verification is off (hard coded).
 c.LTI13Authenticator.endpoint = os.environ["LTI13_ENDPOINT"]
 
 # The LTI 1.3 token url used to validate JWT signatures

--- a/dev/jupyterhub_config.py
+++ b/dev/jupyterhub_config.py
@@ -1,0 +1,88 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# Configuration file for JupyterHub
+import os
+
+c = get_config()
+
+# We rely on environment variables to configure JupyterHub so that we
+# avoid having to rebuild the JupyterHub container every time we change a
+# configuration parameter.
+
+##############################################################################
+# LTI 1.3 Authenticator configuration
+##############################################################################
+# Authenticate users via LTI 1.3
+c.JupyterHub.authenticator_class = "ltiauthenticator.lti13.auth.LTI13Authenticator"
+
+# User name claim containing a string which will be used by Jupyterhub as user name.
+# Must be a unique identifyer of the user on the LTI Platform (LMS).
+c.LTI13Authenticator.username_key = os.environ["LTI13_USERNAME_KEY"]
+
+# The LTI 1.3 authorization url. The url of the platforms (LMS) endpoint for OAuth2
+# authentication
+c.LTI13Authenticator.authorize_url = os.environ["LTI13_AUTHORIZE_URL"]
+
+# The external tool's client id as represented within the platform (LMS)
+# Note: the client id is not required by some LMS's for authentication.
+# Only required, if the JupyterHub is suppose to send back information to the LMS
+c.LTI13Authenticator.client_id = os.environ.get("LTI13_CLIENT_ID", "")
+
+# The JWKS endpoint of the platform (LMS).
+# Currently not used since JWK verification is off (hard coded).
+c.LTI13Authenticator.endpoint = os.environ["LTI13_ENDPOINT"]
+
+# The LTI 1.3 token url used to validate JWT signatures
+c.LTI13Authenticator.token_url = os.environ["LTI13_TOKEN_URL"]
+##############################################################################
+
+
+# Spawn single-user servers as Docker containers
+c.JupyterHub.spawner_class = "dockerspawner.DockerSpawner"
+
+# Spawn containers from this image
+c.DockerSpawner.image = os.environ["DOCKER_NOTEBOOK_IMAGE"]
+
+# JupyterHub requires a single-user instance of the Notebook server, so we
+# default to using the `start-singleuser.sh` script included in the
+# jupyter/docker-stacks *-notebook images as the Docker run command when
+# spawning containers.  Optionally, you can override the Docker run command
+# using the DOCKER_SPAWN_CMD environment variable.
+spawn_cmd = os.environ.get("DOCKER_SPAWN_CMD", "start-singleuser.sh")
+c.DockerSpawner.cmd = spawn_cmd
+
+# Connect containers to this Docker network
+network_name = os.environ["DOCKER_NETWORK_NAME"]
+c.DockerSpawner.use_internal_ip = True
+c.DockerSpawner.network_name = network_name
+
+# Explicitly set notebook directory because we'll be mounting a volume to it.
+# Most jupyter/docker-stacks *-notebook images run the Notebook server as
+# user `jovyan`, and set the notebook directory to `/home/jovyan/work`.
+# We follow the same convention.
+notebook_dir = os.environ.get("DOCKER_NOTEBOOK_DIR") or "/home/jovyan/work"
+c.DockerSpawner.notebook_dir = notebook_dir
+
+# Mount the real user's Docker volume on the host to the notebook user's
+# notebook directory in the container
+c.DockerSpawner.volumes = {"jupyterhub-user-{username}": notebook_dir}
+
+# Remove containers once they are stopped
+c.DockerSpawner.remove = True
+
+# For debugging arguments passed to spawned containers
+c.DockerSpawner.debug = True
+
+# User containers will access hub by container name on the Docker network
+c.JupyterHub.hub_ip = "jupyterhub"
+c.JupyterHub.hub_port = 8080
+
+# Persist hub data on volume mounted inside container
+c.JupyterHub.cookie_secret_file = "/data/jupyterhub_cookie_secret"
+c.JupyterHub.db_url = "sqlite:////data/jupyterhub.sqlite"
+
+# Allowed admins
+admin = os.environ.get("JUPYTERHUB_ADMIN")
+if admin:
+    c.Authenticator.admin_users = [admin]

--- a/ltiauthenticator/lti11/auth.py
+++ b/ltiauthenticator/lti11/auth.py
@@ -140,7 +140,6 @@ class LTI11Authenticator(Authenticator):
         self.log.debug(f"Launch url is: {launch_url}")
 
         if validator.validate_launch_request(launch_url, handler.request.headers, args):
-
             # raise an http error if the username_key is not in the request's arguments.
             if self.username_key not in args.keys():
                 self.log.warning(

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 from jupyterhub.app import JupyterHub
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.handlers import BaseHandler
+from jupyterhub.utils import url_path_join
 from oauthenticator.oauth2 import OAuthenticator
 from tornado.web import HTTPError
 from traitlets.config import List as TraitletsList
@@ -115,9 +116,14 @@ class LTI13Authenticator(OAuthenticator):
         """,
     )
 
+    def login_url(self, base_url):
+        return url_path_join(base_url, "lti13", "oauth_login")
+
     def get_handlers(self, app: JupyterHub) -> List[BaseHandler]:
         return [
-            ("/lti13/config", LTI13ConfigHandler),
+            (r"/lti13/oauth_login", self.login_handler),
+            (r"/lti13/oauth_callback", self.callback_handler),
+            (r"/lti13/config", LTI13ConfigHandler),
         ]
 
     async def authenticate(

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -9,17 +9,25 @@ from urllib.parse import quote, unquote, urlparse
 import pem
 from Crypto.PublicKey import RSA
 from jupyterhub.handlers import BaseHandler
+from jupyterhub.utils import url_path_join
 from oauthenticator.oauth2 import (
     OAuthCallbackHandler,
     OAuthLoginHandler,
     _serialize_state,
-    guess_callback_uri,
 )
 from tornado.httputil import url_concat
 from tornado.web import HTTPError, RequestHandler
 
 from ..utils import convert_request_to_dict, get_client_protocol, get_jwk
 from .validator import LTI13LaunchValidator
+
+
+def guess_callback_uri(protocol, host, hub_server_url):
+    return "{proto}://{host}{path}".format(
+        proto=protocol,
+        host=host,
+        path=url_path_join(hub_server_url, "/lti13/oauth_callback"),
+    )
 
 
 class LTI13ConfigHandler(BaseHandler):
@@ -224,7 +232,7 @@ class LTI13LoginHandler(OAuthLoginHandler):
         client_id = args["client_id"]
         self.log.debug(f"client_id is {client_id}")
         redirect_uri = guess_callback_uri(
-            "https", self.request.host, self.hub.server.base_url
+            self.request.protocol, self.request.host, self.hub.server.base_url
         )
         self.log.info(f"redirect_uri: {redirect_uri}")
         state = self.get_state()

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -224,11 +224,7 @@ class LTI13LoginHandler(OAuthLoginHandler):
         client_id = args["client_id"]
         self.log.debug(f"client_id is {client_id}")
 
-        redirect_uri = "{proto}://{host}{path}".format(
-            proto=self.request.protocol,
-            host=self.request.host,
-            path=url_path_join(self.hub.server.base_url, "/lti13/oauth_callback"),
-        )
+        redirect_uri = self.authenticator.get_callback_url()
         self.log.debug(f"redirect_uri is: {redirect_uri}")
 
         state = self.get_state()

--- a/tests/lti11/test_lti11_authenticator.py
+++ b/tests/lti11/test_lti11_authenticator.py
@@ -20,7 +20,6 @@ async def test_authenticator_uses_lti11validator(
     with patch.object(
         LTI11LaunchValidator, "validate_launch_request", return_value=True
     ) as mock_validator:
-
         authenticator = MockLTI11Authenticator()
         authenticator.username_key = "custom_canvas_user_id"
         handler = Mock(spec=RequestHandler)

--- a/tests/lti13/mocking.py
+++ b/tests/lti13/mocking.py
@@ -1,8 +1,4 @@
-from jupyterhub.app import JupyterHub
-from jupyterhub.handlers import BaseHandler
-
 from ltiauthenticator.lti13.auth import LTI13Authenticator
-from ltiauthenticator.lti13.handlers import LTI13ConfigHandler
 
 
 class MockLTI13Authenticator(LTI13Authenticator):
@@ -20,8 +16,3 @@ class MockLTI13Authenticator(LTI13Authenticator):
     authorize_url = "https://my.platform.domain/api/lti/authorize_redirect"
     endpoint = "https://my.platform.domain"
     token_url = "https://my.platform.domain/login/oauth2/token"
-
-    def get_handlers(self, app: JupyterHub) -> BaseHandler:
-        return [
-            (f"{self.config_url}", LTI13ConfigHandler),
-        ]

--- a/tests/lti13/test_lti13_handlers.py
+++ b/tests/lti13/test_lti13_handlers.py
@@ -5,4 +5,7 @@ async def test_lti_13_handler_paths(app):
     """Test if all handlers are correctly set with the LTI13Authenticator."""
     auth = MockLTI13Authenticator()
     handlers = auth.get_handlers(app)
-    assert handlers[0][0] == "/lti13/config"
+    handler_paths = [route[0] for route in handlers]
+    assert "/lti13/config" in handler_paths
+    assert "/lti13/oauth_login" in handler_paths
+    assert "/lti13/oauth_callback" in handler_paths


### PR DESCRIPTION
This adds a docker compose deployment and instructions and configuration to set up the [TAO LTI 1.3 devKit](https://github.com/oat-sa/devkit-lti1p3) as the LTI platform to initiate the login flow. 