### PR TITLE
docs: Fix read-the-docs build with pydata-sphinx-theme==0.13.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,6 +86,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/jupyterhub/ltiauthenticator/",
     "use_edit_page_button": True,
+    "icon_links": [],
 }
 html_context = {
     "github_user": "jupyterhub",


### PR DESCRIPTION
`pydata-sphinx-theme==0.13.0` breaks rtd build. Instead of pinning the dependency, I have fixed the issue by providing the default value for `html_theme_options['icon_link']`. IMO, this should be the most maintainable solution.

Ref: https://github.com/pydata/pydata-sphinx-theme/issues/1220