### PR TITLE
Lti 1.1 make oauth_callback optional

### DIFF
--- a/ltiauthenticator/lti11/constants.py
+++ b/ltiauthenticator/lti11/constants.py
@@ -51,12 +51,20 @@ LTI11_LIS_OPTION = [
 
 # https://www.imsglobal.org/specs/ltiv1p1/implementation-guide
 # Section 4.2
+#
+# Note: Some Tool Consumer do not provide a oauth_callback parameter and it is not required
+# by this authenticator. Since message verification requires the base string to remain unchanged,
+# we do not set the parameter to its default value (as suggested by the LTI 1.1 implementation guide)
+# but rather do not require oauth_callback as manadatory parameter.
+#
+# References:
+# https://github.com/jupyterhub/ltiauthenticator/issues/136
 LTI11_OAUTH_ARGS = [
     "oauth_consumer_key",
     "oauth_signature_method",
     "oauth_timestamp",
     "oauth_nonce",
-    "oauth_callback",
+    # "oauth_callback",
     "oauth_version",
     "oauth_signature",
 ]

--- a/ltiauthenticator/lti11/validator.py
+++ b/ltiauthenticator/lti11/validator.py
@@ -1,6 +1,7 @@
 import time
 from collections import OrderedDict
 from typing import Any, Dict
+from typing import OrderedDict as OrderedDictType
 
 from oauthlib.common import safe_string_equals
 from oauthlib.oauth1.rfc5849 import Client, signature
@@ -29,7 +30,7 @@ class LTI11LaunchValidator(LoggingConfigurable):
 
     # Keep a class-wide, global list of nonces so we can detect & reject
     # replay attacks. This possibly makes this non-threadsafe, however.
-    nonces: OrderedDict[int, set] = OrderedDict()
+    nonces: OrderedDictType[int, set] = OrderedDict()
 
     def __init__(self, consumers):
         self.consumers = consumers
@@ -134,7 +135,7 @@ class LTI11LaunchValidator(LoggingConfigurable):
         return True
 
     @staticmethod
-    def set_default_oauth_callback(args: dict[str, Any]) -> dict[str, Any]:
+    def set_default_oauth_callback(args: Dict[str, Any]) -> Dict[str, Any]:
         """Set the default value of oauth_callback.
 
         See https://www.imsglobal.org/specs/ltiv1p1/implementation-guide#toc-4

--- a/ltiauthenticator/lti11/validator.py
+++ b/ltiauthenticator/lti11/validator.py
@@ -59,7 +59,6 @@ class LTI11LaunchValidator(LoggingConfigurable):
           HTTPError if a required argument is not inclued in the POST request.
         """
         # Ensure that required oauth_* body arguments are included in the request
-        args = self.set_default_oauth_callback(args)
         for param in LTI11_OAUTH_ARGS:
             if param not in args.keys():
                 raise HTTPError(
@@ -133,12 +132,3 @@ class LTI11LaunchValidator(LoggingConfigurable):
             raise HTTPError(401, "Invalid oauth_signature")
 
         return True
-
-    @staticmethod
-    def set_default_oauth_callback(args: Dict[str, Any]) -> Dict[str, Any]:
-        """Set the default value of oauth_callback.
-
-        See https://www.imsglobal.org/specs/ltiv1p1/implementation-guide#toc-4
-        """
-        args.setdefault("oauth_callback", "about:blank")
-        return args

--- a/tests/lti11/conftest.py
+++ b/tests/lti11/conftest.py
@@ -1,7 +1,7 @@
 import os
 import secrets
 import time
-from typing import Dict
+from typing import Dict, Optional
 from unittest.mock import Mock
 
 import pytest
@@ -57,11 +57,11 @@ def get_launch_args():
         lms_vendor: str = "canvas",
         oauth_consumer_key: str = "my_consumer_key",
         oauth_consumer_secret: str = "my_shared_secret",
+        oauth_callback: Optional[str] = "about:blank",
     ) -> Dict[str, str]:
         oauth_timestamp = str(int(time.time()))
         oauth_nonce = secrets.token_urlsafe(32)
         args = {
-            "oauth_callback": "about:blank",
             "oauth_consumer_key": oauth_consumer_key,
             "oauth_timestamp": str(int(oauth_timestamp)),
             "oauth_nonce": str(oauth_nonce),
@@ -101,6 +101,8 @@ def get_launch_args():
             "user_id": "185d6c59731a553009ca9b59ca3a885100000",
             "user_image": "https://lms.example.com/avatar-50.png",
         }
+        if oauth_callback is not None:
+            args["oauth_callback"] = oauth_callback
         extra_args = {"my_key": "this_value"}
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         launch_url = "http://jupyterhub/hub/lti/launch"

--- a/tests/lti11/conftest.py
+++ b/tests/lti11/conftest.py
@@ -1,7 +1,7 @@
 import os
 import secrets
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 from unittest.mock import Mock
 
 import pytest
@@ -58,7 +58,7 @@ def get_launch_args():
         oauth_consumer_key: str = "my_consumer_key",
         oauth_consumer_secret: str = "my_shared_secret",
         oauth_callback: Optional[str] = "about:blank",
-    ) -> Dict[str, str]:
+    ) -> Tuple[str, Dict[str, str], Dict[str, str]]:
         oauth_timestamp = str(int(time.time()))
         oauth_nonce = secrets.token_urlsafe(32)
         args = {
@@ -124,7 +124,7 @@ def get_launch_args():
         args["oauth_signature"] = signature.sign_hmac_sha1_with_client(
             base_string, client
         )
-        return args
+        return launch_url, headers, args
 
     return _get_launch_args
 

--- a/tests/lti11/test_lti11_validator.py
+++ b/tests/lti11/test_lti11_validator.py
@@ -207,6 +207,9 @@ def test_launch_with_empty_oauth_signature_method_value(
 def test_launch_with_missing_oauth_callback_key(get_launch_args):
     """
     Does the launch request work with a missing oauth_callback key?
+    It should, see https://www.imsglobal.org/specs/ltiv1p1/implementation-guide#toc-4.
+
+    Note that some LMS do not add `oauth_callback` to the list of parameters.
     """
     oauth_consumer_key = "my_consumer_key"
     oauth_consumer_secret = "my_shared_secret"
@@ -222,8 +225,7 @@ def test_launch_with_missing_oauth_callback_key(get_launch_args):
 
     validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
-    with pytest.raises(HTTPError):
-        validator.validate_launch_request(launch_url, headers, args)
+    assert validator.validate_launch_request(launch_url, headers, args)
 
 
 def test_launch_with_empty_oauth_callback_value(

--- a/tests/lti11/test_lti11_validator.py
+++ b/tests/lti11/test_lti11_validator.py
@@ -1,24 +1,27 @@
+from typing import Dict, Tuple
+
 import pytest
 from tornado.web import HTTPError
 
 from ltiauthenticator.lti11.validator import LTI11LaunchValidator
 
 
+def args_test_setup(
+    arg_func, key: str = "my_consumer_key", secret: str = "my_shared_secret", **kwargs
+) -> Tuple[LTI11LaunchValidator, str, Dict[str, str], Dict[str, str]]:
+    """Common test setup logic"""
+    launch_url, headers, args = arg_func(
+        oauth_consumer_key=key, oauth_consumer_secret=secret, **kwargs
+    )
+    validator = LTI11LaunchValidator({key: secret})
+    return validator, launch_url, headers, args
+
+
 def test_basic_lti11_launch_request(get_launch_args):
     """
     Does a standard launch request work?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     assert validator.validate_launch_request(launch_url, headers, args)
 
@@ -27,19 +30,8 @@ def test_launch_with_missing_oauth_nonce_key(get_launch_args):
     """
     Does the launch request work with a missing oauth_nonce key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["oauth_nonce"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -51,17 +43,7 @@ def test_launch_with_empty_oauth_nonce_value(
     """
     Does the launch request work with an empty oauth_nonce value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_nonce"] = ""
@@ -72,19 +54,8 @@ def test_launch_with_missing_oauth_timestamp_key(get_launch_args):
     """
     Does the launch request work with a missing oauth_timestamp key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["oauth_timestamp"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -96,19 +67,8 @@ def test_launch_with_missing_oauth_consumer_key_key(
     """
     Does the launch request work with a missing oauth_consumer_key key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["oauth_consumer_key"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -120,17 +80,7 @@ def test_launch_with_empty_oauth_consumer_key_value(
     """
     Does the launch request work with an empty oauth_consumer_key value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_consumer_key"] = ""
@@ -143,17 +93,7 @@ def test_launch_with_fake_oauth_consumer_key_value(
     """
     Does the launch request work when the consumer_key isn't correct?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_consumer_key"] = [b"fake_consumer_key"][0].decode("utf-8")
@@ -166,17 +106,8 @@ def test_launch_with_missing_oauth_signature_method_key(
     """
     Does the launch request work with a missing oauth_signature_method key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(oauth_consumer_key, oauth_consumer_secret)
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["oauth_signature_method"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
-
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
 
@@ -187,17 +118,7 @@ def test_launch_with_empty_oauth_signature_method_value(
     """
     Does the launch request work with an empty oauth_signature_method value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_signature_method"] = ""
@@ -211,16 +132,9 @@ def test_launch_with_missing_oauth_callback_key(get_launch_args):
 
     Note that some LMS do not add `oauth_callback` to the list of parameters.
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key, oauth_consumer_secret, oauth_callback=None
+    validator, launch_url, headers, args = args_test_setup(
+        get_launch_args, oauth_callback=None
     )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     assert validator.validate_launch_request(launch_url, headers, args)
 
@@ -231,20 +145,9 @@ def test_launch_with_empty_oauth_callback_value(
     """
     Does the launch request work with an empty oauth_callback value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-        oauth_callback="",
+    validator, launch_url, headers, args = args_test_setup(
+        get_launch_args, oauth_callback=""
     )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
-
-    args["oauth_callback"] = ""
     validator.validate_launch_request(launch_url, headers, args)
 
 
@@ -252,19 +155,8 @@ def test_launch_with_missing_oauth_version_key(get_launch_args):
     """
     Does the launch request work with a missing oauth_version key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["oauth_version"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -276,17 +168,7 @@ def test_launch_with_empty_oauth_version_value(
     """
     Does the launch request work with an empty oauth_version value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_version"] = ""
@@ -297,19 +179,8 @@ def test_launch_with_missing_oauth_signature_key(get_launch_args):
     """
     Does the launch request work with a missing oauth_signature key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["oauth_signature"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -321,17 +192,7 @@ def test_launch_with_empty_oauth_signature_value(
     """
     Does the launch request work with an empty oauth_signature value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_signature"] = ""
@@ -342,17 +203,7 @@ def test_unregistered_consumer_key(get_launch_args):
     """
     Does the launch request work with a consumer key that does not match?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     args["oauth_consumer_key"] = "fake_consumer_key"
 
@@ -364,18 +215,10 @@ def test_unregistered_shared_secret(get_launch_args):
     """
     Does the launch request work with a shared secret that does not match?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
+    _, launch_url, headers, args = args_test_setup(get_launch_args)
+    validator = LTI11LaunchValidator(
+        {args["oauth_consumer_key"]: "my_other_shared_secret"}
     )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: "my_other_shared_secret"})
-
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
 
@@ -384,19 +227,8 @@ def test_launch_with_missing_lti_message_type(get_launch_args):
     """
     Does the launch request work with a missing lti_message_type argument?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["lti_message_type"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -408,17 +240,7 @@ def test_launch_with_empty_lti_message_type(
     """
     Does the launch request work with an empty lti_message_type value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["lti_message_type"] = ""
@@ -429,19 +251,8 @@ def test_launch_with_missing_lti_version(get_launch_args):
     """
     Does the launch request work with a missing oauth_signature key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["lti_version"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -451,17 +262,7 @@ def test_launch_with_empty_lti_version(get_launch_args):
     """
     Does the launch request work with an empty oauth_signature value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["lti_version"] = ""
@@ -472,19 +273,8 @@ def test_launch_with_missing_resource_link_id(get_launch_args):
     """
     Does the launch request work with a missing resource_link_id key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["resource_link_id"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -496,17 +286,7 @@ def test_launch_with_empty_resource_link_id(
     """
     Does the launch request work with an empty resource_link_id value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["resource_link_id"] = ""
@@ -517,19 +297,8 @@ def test_launch_with_missing_user_id_key(get_launch_args):
     """
     Does the launch request work with a missing user_id key?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
     del args["user_id"]
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
     with pytest.raises(HTTPError):
         validator.validate_launch_request(launch_url, headers, args)
@@ -539,17 +308,7 @@ def test_launch_with_empty_user_id_value(get_launch_args):
     """
     Does the launch request work with an empty user_id value?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["user_id"] = ""
@@ -563,17 +322,7 @@ def test_launch_with_same_oauth_timestamp_different_oauth_nonce(
     Does the launch request pass with when using a different nonce with the
     same timestamp?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
-    )
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_nonce"] = "fake_nonce"
@@ -587,14 +336,7 @@ def test_launch_with_same_oauth_nonce_different_oauth_timestamp(
     Does the launch request pass with when using a different timestamp with the
     same nonce?
     """
-    oauth_consumer_key = "my_consumer_key"
-    oauth_consumer_secret = "my_shared_secret"
-    launch_url = "http://jupyterhub/hub/lti/launch"
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-
-    args = get_launch_args(oauth_consumer_key, oauth_consumer_secret)
-
-    validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
+    validator, launch_url, headers, args = args_test_setup(get_launch_args)
 
     with pytest.raises(HTTPError):
         args["oauth_timestamp"] = "0123456789"

--- a/tests/lti11/test_lti11_validator.py
+++ b/tests/lti11/test_lti11_validator.py
@@ -217,11 +217,8 @@ def test_launch_with_missing_oauth_callback_key(get_launch_args):
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     args = get_launch_args(
-        oauth_consumer_key,
-        oauth_consumer_secret,
+        oauth_consumer_key, oauth_consumer_secret, oauth_callback=None
     )
-
-    del args["oauth_callback"]
 
     validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
@@ -242,13 +239,13 @@ def test_launch_with_empty_oauth_callback_value(
     args = get_launch_args(
         oauth_consumer_key,
         oauth_consumer_secret,
+        oauth_callback="",
     )
 
     validator = LTI11LaunchValidator({oauth_consumer_key: oauth_consumer_secret})
 
-    with pytest.raises(HTTPError):
-        args["oauth_callback"] = ""
-        validator.validate_launch_request(launch_url, headers, args)
+    args["oauth_callback"] = ""
+    validator.validate_launch_request(launch_url, headers, args)
 
 
 def test_launch_with_missing_oauth_version_key(get_launch_args):


### PR DESCRIPTION
The `oauth_callback` parameter in the launch request is not required by LTI 1.1 and some tool consumer do not provide them in the request. According to th e[LTI 1.1 implementation notes](https://www.imsglobal.org/specs/ltiv1p1/implementation-guide#toc-4), setting a default value value is fine.

See #136