### PR TITLE
feat(lti13): Allow username key from custom claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,11 @@ The Moodle setup is very similar to both the Open edX and Canvas setups describe
 
 #### Common Configuration Settings
 
-Like LTI 1.1, LTI 1.3 is an open standard. Many Learning Management System (LMS) vendors support the LTI 1.3 standard and as such vendors are able to integrate with various LMS's as External Tools.
+Like LTI 1.1, LTI 1.3 is an open standard.
+Many Learning Management System (LMS) vendors support the LTI 1.3 standard and as such vendors are able to integrate with various LMS's as External Tools.
 
-Start by following the steps below to configure your JupyterHub setup with the basic settings. Then, navigate to your LMS vendor's section to complete the installation and configuration steps.
+Start by following the steps below to configure your JupyterHub setup with the basic settings.
+Then, navigate to your LMS vendor's section to complete the installation and configuration steps.
 
 > **Note**: if your LMS is not listed feel free to send us a PR with instructions for this new LMS.
 
@@ -285,24 +287,34 @@ The table below describes the configuration options available with the LTI v1.1 
 | consumers                               | Yes      | The key/value pair that represents the client key and shared secret      | `{}`                               |
 | username_key                            | No       | The LTI 1.1 launch parameter that contains the JupyterHub username value | `canvas_custom_user_id`            |
 
-#### The Username Key Setting (LTI11Authenticator.username_key)
+#### The Username Key Setting (LTI13Authenticator.username_key)
 
-Regardless of the LMS vendor you are using (Canvas, Moodle, Open edX, etc), the user's name will default to use the `custom_canvas_user_id`. (This is due to legacy behavior and will default to a more generic LTI 1.1 parameter in a future release). Change the `username_key` setting if you would like to use another value from the LTI 1.1 launch request.
+The username is inferred from the ID token sent by the platform (LMS) during the login flow based on the setting of the `username_key` traitlet.
+The default is `email`, but all other top-level claims of the ID token may be chosen.
+The list of available values depends on the LMS vendor you are using and how your LMS is configured, but you take a look at [this example](http://www.imsglobal.org/spec/lti/v1p3/#examplelinkrequest) to get an idea of the available values.
+If you are in doubt about the content of the ID token sent by the LMS, you may use [an external test tool](https://saltire.lti.app/tool) with your LMS to capture the ID token.
 
-The example below illustrates how to fetch the user's email to set the JupyterHub username by specifying the `lis_person_contact_email_primary` LTI 1.1 launch request parameter:
+Your LMS may provide additional keys in the LTI 1.3 login initiation flow that you can use to set the username.
+In most cases these are located in the `https://purl.imsglobal.org/spec/lti/claim/custom` claim.
+In this case, `username_key` must be prefixed with "custom_".
+For example, `username_key` value "custom_uname" will set the username to the value of the parameter `uname` within the `https://purl.imsglobal.org/spec/lti/claim/custom` claim.
+
+If your platform's LTI 1.3 settings are defined with privacy enabled or if the given `username_key` is not found within the ID token, then by default the `sub` claim is used to set the username.
+
+You may also have the option of using [variable substitutions](http://www.imsglobal.org/spec/lti/v1p3/#customproperty) to fetch values that aren't provided with your vendor's standard LTI 1.3 login initiation flow request.
+
+The example below illustrates how to fetch the user's given name to set the JupyterHub username:
 
 ```python
 # Set the user's email as their user id
-c.LTIAuthenticator.username_key = 'lis_person_contact_email_primary'
+c.LTI13Authenticator.username_key = "given_name"
 ```
-
-A [partial list of keys in an LTI request](https://www.edu-apps.org/code.html#params) is available as a reference if you would like to use another value to set the JupyterHub username. As a general rule of thumb, Personally Identifiable Information (PII) values are represented with the `lis_person_*` arguments in the launch request. Your LMS provider might also implement custom keys you can use, such as with the use of [custom parameter substitution](https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide).
 
 #### LTI 1.3 Configuration JSON Settings
 
-The LTI 1.3 configuration XML settings are available at `/lti11/config` endpoint. Some LMS vendors accept XML and/or URLs that render the configuration XML to simplify the LTI 1.1 External Tool installation process.
+The LTI 1.3 configuration JSON settings are available at `/lti13/config` endpoint. Some LMS vendors accept URLs that render the configuration JSON to simplify the LTI 1.3 tool installation process.
 
-You may customize these settings with the `config_*` configuration options described in the [common configuration settings](#common-configuration-settings) section.
+You may customize these settings with the `tool_name` and `tool_description` configuration options.
 
 #### Custom Configuration with JupyterHub's Helm Chart
 

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -9,9 +9,9 @@ from oauthenticator.oauth2 import OAuthenticator
 from traitlets import List as TraitletsList
 from traitlets import Unicode
 
-from .handlers import LTI13CallbackHandler, LTI13ConfigHandler, LTI13LoginInitHandler
 from .constants import LTI13_CUSTOM_CLAIM
-from .validator import LoginError
+from .error import LoginError
+from .handlers import LTI13CallbackHandler, LTI13ConfigHandler, LTI13LoginInitHandler
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/ltiauthenticator/lti13/auth.py
+++ b/ltiauthenticator/lti13/auth.py
@@ -84,14 +84,19 @@ class LTI13Authenticator(OAuthenticator):
           - Given name: given_name
         
         Your LMS (Canvas / Open EdX / Moodle / others) may provide additional keys in the
-        LTI 1.3 login initiatino flow that you can use to set the username. In most cases these
-        are located in the `https://purl.imsglobal.org/spec/lti/claim/custom` claim. You may also
-        have the option of using variable substitutions to fetch values that aren't provided with
-        your vendor's standard LTI 1.3 login initiation flow request. If your platform's LTI 1.3
-        settings are defined with privacy enabled, then by default the `sub` claim is used to set the
-        username.
+        LTI 1.3 login initiation flow that you can use to set the username. In most cases these
+        are located in the `https://purl.imsglobal.org/spec/lti/claim/custom` claim. In this case,
+        `username_key` must be prefixed with "custom_". For example, `username_key` value "custom_uname"
+        will set the username to the value of the parameter `uname` within the
+        `https://purl.imsglobal.org/spec/lti/claim/custom` claim.
+        
+        If your platform's LTI 1.3 settings are defined with privacy enabled, then by default the `sub`
+        claim is used to set the username.
+        
+        You may also have the option of using variable substitutions to fetch values that aren't provided with
+        your vendor's standard LTI 1.3 login initiation flow request.
 
-        Reference the IMS LTI specification on variable substitutions:
+        Reference to the IMS LTI specification on variable substitutions:
         http://www.imsglobal.org/spec/lti/v1p3/#customproperty.
         """,
     )
@@ -176,12 +181,14 @@ class LTI13Authenticator(OAuthenticator):
 
         username = data.get(username_key)
         if not username:
+            logger.warning(
+                f"Cannot find the key {username_key} in the ID token. `sub` used instread."
+            )
             username = token.get("sub")
         if not username:
             raise LoginError(
                 f"Unable to set the username with username_key {username_key}"
             )
-
         return username
 
 

--- a/ltiauthenticator/lti13/constants.py
+++ b/ltiauthenticator/lti13/constants.py
@@ -3,6 +3,8 @@
 # https://www.imsglobal.org/spec/security/v1p0/#step-1-third-party-initiated-login
 from typing import Any, Dict
 
+LTI13_CUSTOM_CLAIM = "https://purl.imsglobal.org/spec/lti/claim/custom"
+
 LTI13_INIT_LOGIN_REQUEST_ARGS = [
     "iss",
     "login_hint",

--- a/ltiauthenticator/lti13/error.py
+++ b/ltiauthenticator/lti13/error.py
@@ -1,0 +1,35 @@
+"""All custom exceptions defined in one place."""
+
+
+class ValidationError(Exception):
+    """Base class for validation exceptions."""
+
+
+class MissingRequiredArgumentError(ValidationError):
+    """Exception raised for missing required request arguments."""
+
+    pass
+
+
+class IncorrectValueError(ValidationError):
+    """Exception raised for incorrect values."""
+
+    pass
+
+
+class TokenError(ValidationError):
+    """Exception raised for failed JWT decoding or verification."""
+
+    pass
+
+
+class InvalidAudienceError(ValidationError):
+    """Exception raised for invalid audience."""
+
+    pass
+
+
+class LoginError(Exception):
+    """Lookup of username in ID token failed"""
+
+    pass

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -17,7 +17,12 @@ from tornado.httputil import url_concat
 from tornado.web import HTTPError, RequestHandler
 
 from ..utils import convert_request_to_dict, get_client_protocol
-from .validator import InvalidAudienceError, LTI13LaunchValidator, ValidationError
+from .validator import (
+    InvalidAudienceError,
+    LTI13LaunchValidator,
+    ValidationError,
+    LoginError,
+)
 
 NONCE_STATE_COOKIE_NAME = "lti13authenticator-nonce-state"
 
@@ -337,7 +342,10 @@ class LTI13CallbackHandler(OAuthCallbackHandler):
         except ValidationError as e:
             raise HTTPError(400, str(e))
 
-        user = await self.login_user(id_token)
+        try:
+            user = await self.login_user(id_token)
+        except LoginError as e:
+            raise HTTPError(400, str(e))
         self.log.debug(f"user logged in: {user}")
         if user is None:
             raise HTTPError(403, "User missing or null")

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -17,12 +17,8 @@ from tornado.httputil import url_concat
 from tornado.web import HTTPError, RequestHandler
 
 from ..utils import convert_request_to_dict, get_client_protocol
-from .validator import (
-    InvalidAudienceError,
-    LTI13LaunchValidator,
-    ValidationError,
-    LoginError,
-)
+from .error import InvalidAudienceError, LoginError, ValidationError
+from .validator import LTI13LaunchValidator
 
 NONCE_STATE_COOKIE_NAME = "lti13authenticator-nonce-state"
 

--- a/ltiauthenticator/lti13/validator.py
+++ b/ltiauthenticator/lti13/validator.py
@@ -6,12 +6,18 @@ import jwt
 from traitlets import Int
 from traitlets.config import LoggingConfigurable
 
-from ltiauthenticator.lti13.constants import (
+from .constants import (
     LTI13_AUTH_RESPONSE_ARGS,
     LTI13_DEEP_LINKING_REQUIRED_CLAIMS,
     LTI13_GENERAL_REQUIRED_CLAIMS,
     LTI13_INIT_LOGIN_REQUEST_ARGS,
     LTI13_RESOURCE_LINK_REQUEST_REQUIRED_CLAIMS,
+)
+from .error import (
+    IncorrectValueError,
+    InvalidAudienceError,
+    MissingRequiredArgumentError,
+    TokenError,
 )
 
 
@@ -232,37 +238,3 @@ class LTI13LaunchValidator(LoggingConfigurable):
                 id_token, LTI13_RESOURCE_LINK_REQUEST_REQUIRED_CLAIMS.keys()
             )
             self._check_resource_link_id(id_token)
-
-
-class ValidationError(Exception):
-    """Base class for validation exceptions."""
-
-
-class MissingRequiredArgumentError(ValidationError):
-    """Exception raised for missing required request arguments."""
-
-    pass
-
-
-class IncorrectValueError(ValidationError):
-    """Exception raised for incorrect values."""
-
-    pass
-
-
-class TokenError(ValidationError):
-    """Exception raised for failed JWT decoding or verification."""
-
-    pass
-
-
-class InvalidAudienceError(ValidationError):
-    """Exception raised for invalid audience."""
-
-    pass
-
-
-class LoginError(Exception):
-    """Lookup of username in ID token failed"""
-
-    pass

--- a/ltiauthenticator/lti13/validator.py
+++ b/ltiauthenticator/lti13/validator.py
@@ -260,3 +260,9 @@ class InvalidAudienceError(ValidationError):
     """Exception raised for invalid audience."""
 
     pass
+
+
+class LoginError(Exception):
+    """Lookup of username in ID token failed"""
+
+    pass

--- a/tests/lti13/test_lti13_authenticator.py
+++ b/tests/lti13/test_lti13_authenticator.py
@@ -8,8 +8,9 @@ test_lti13_validator.py.
 import pytest
 from tornado.web import RequestHandler
 
-from ltiauthenticator.lti13.auth import LTI13Authenticator, LoginError
+from ltiauthenticator.lti13.auth import LTI13Authenticator
 from ltiauthenticator.lti13.constants import LTI13_CUSTOM_CLAIM
+from ltiauthenticator.lti13.error import LoginError
 
 
 async def test_authenticator_returned_username_with_sub(

--- a/tests/lti13/test_lti13_handlers.py
+++ b/tests/lti13/test_lti13_handlers.py
@@ -5,6 +5,7 @@ from tornado.httputil import HTTPServerRequest
 from tornado.web import HTTPError
 
 import ltiauthenticator.lti13.handlers
+from ltiauthenticator.lti13.error import InvalidAudienceError
 from ltiauthenticator.lti13.handlers import (
     NONCE_STATE_COOKIE_NAME,
     LTI13CallbackHandler,
@@ -12,7 +13,7 @@ from ltiauthenticator.lti13.handlers import (
     get_nonce,
     make_nonce_state,
 )
-from ltiauthenticator.lti13.validator import InvalidAudienceError, LTI13LaunchValidator
+from ltiauthenticator.lti13.validator import LTI13LaunchValidator
 from ltiauthenticator.utils import convert_request_to_dict
 
 from .mocking import MockLTI13Authenticator

--- a/tests/lti13/test_lti13_validator.py
+++ b/tests/lti13/test_lti13_validator.py
@@ -1,12 +1,12 @@
 import pytest
 
-from ltiauthenticator.lti13.validator import (
+from ltiauthenticator.lti13.error import (
     IncorrectValueError,
     InvalidAudienceError,
-    LTI13LaunchValidator,
     MissingRequiredArgumentError,
     TokenError,
 )
+from ltiauthenticator.lti13.validator import LTI13LaunchValidator
 
 from .mocking import patched_jwk_client
 


### PR DESCRIPTION
If `username_key` is prefixed by "cutom_", the prefix will be removed and the key will be looked up in the `custom` claim of the ID token.