### PR TITLE
fix: compatibility with XSRF check introduced in Jupyterhub 4.0.0

### DIFF
--- a/ltiauthenticator/lti11/handlers.py
+++ b/ltiauthenticator/lti11/handlers.py
@@ -23,7 +23,7 @@ class LTI11AuthenticateHandler(BaseHandler):
     def check_xsrf_cookie(self):
         """
         Do not attempt to check for xsrf parameter in POST requests. LTI requests are
-        meant to be cross-site, so there is no need to perform this verification.
+        meant to be cross-site, so it must not be verified.
         """
         return
 

--- a/ltiauthenticator/lti11/handlers.py
+++ b/ltiauthenticator/lti11/handlers.py
@@ -20,6 +20,13 @@ class LTI11AuthenticateHandler(BaseHandler):
         # Make sure that hub cookie is always set, even if the user was already logged in
         self.set_hub_cookie(user)
 
+    def check_xsrf_cookie(self):
+        """
+        Do not attempt to check for xsrf parameter in POST requests. LTI requests are
+        meant to be cross-site, so there is no need to perform this verification.
+        """
+        return
+
     @gen.coroutine
     def post(self):
         """

--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -131,6 +131,13 @@ class LTI13LoginInitHandler(OAuthLoginHandler):
     LTI 1.3 standard.
     """
 
+    def check_xsrf_cookie(self):
+        """
+        Do not attempt to check for xsrf parameter in POST requests. LTI requests are
+        meant to be cross-site, so it must not be verified.
+        """
+        return
+
     def authorize_redirect(
         self,
         redirect_uri: str,
@@ -322,6 +329,13 @@ class LTI13CallbackHandler(OAuthCallbackHandler):
     """
 
     _nonce_state_cookie = None
+
+    def check_xsrf_cookie(self):
+        """
+        Do not attempt to check for xsrf parameter in POST requests. LTI requests are
+        meant to be cross-site, so it must not be verified.
+        """
+        return
 
     async def get(self):
         """Overrides the upstream get handler and always raise HTTPError 405."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jupyterhub>=1.2",
     "oauthenticator>=15.1.0",
     "oauthlib>=3.2.2",
-    "PyJWT[crypto]>=2.6.0",
+    "PyJWT[crypto]>=2.7.0",
 ]
 dynamic = ["version"]
 

--- a/tests/lti13/test_lti13_validator.py
+++ b/tests/lti13/test_lti13_validator.py
@@ -156,6 +156,7 @@ def test_verify_and_decode_jwt_fails_on_missing_aud(
         )
     assert str(e.value) == "Invalid audience"
 
+
 # Tests of validate_launch_request()
 # -------------------------------------------------------------------------------
 def test_validate_minimal_launch_request(minimal_launch_req_jwt_decoded):

--- a/tests/lti13/test_lti13_validator.py
+++ b/tests/lti13/test_lti13_validator.py
@@ -137,8 +137,24 @@ def test_verify_and_decode_jwt_fails_on_incorrect_aud(
             jwks_endpoint="https://lti-ri.imsglobal.org/platforms/3691/platform_keys/3396.json",
             jwks_algorithms=["RS256"],
         )
-    assert str(e.value) == "Invalid audience"
+    assert str(e.value) == "Audience doesn't match"
 
+
+def test_verify_and_decode_jwt_fails_on_missing_aud(
+    launch_req_jwt, launch_req_jwt_decoded, jwks_endpoint_response
+):
+    validator = LTI13LaunchValidator()
+    with patched_jwk_client(jwks_endpoint_response), pytest.raises(
+        InvalidAudienceError
+    ) as e:
+        validator.verify_and_decode_jwt(
+            encoded_jwt=launch_req_jwt,
+            issuer=launch_req_jwt_decoded["iss"],
+            audience=None,
+            jwks_endpoint="https://lti-ri.imsglobal.org/platforms/3691/platform_keys/3396.json",
+            jwks_algorithms=["RS256"],
+        )
+    assert str(e.value) == "Invalid audience"
 
 # Tests of validate_launch_request()
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
JupyterHub 4.0.0 extended the verification of the _xsrf parameter in POST requests. But LTI requests do not include this parameter, and requests triggered the following error:

    403: Forbidden '_xsrf' argument missing from POST

LTIAuthenticator thus was not compatible with JupyterHub 4.0.0. This PR resolves the issue for LTI 1.1 by ignoring the xsrf check; a similar change should be introduced for the LTI 1.3 authenticator.

See the tornado docs for more information on `check_xsrf_cookie`: https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.check_xsrf_cookie

Close #157.