### PR TITLE
Fix protocol for redirect_uri in handlers.py

### DIFF
--- a/ltiauthenticator/lti13/handlers.py
+++ b/ltiauthenticator/lti13/handlers.py
@@ -292,7 +292,7 @@ class LTI13LoginInitHandler(OAuthLoginHandler):
     def get_redirect_uri(self) -> str:
         """Create uri to redirect user agent to after successful authorization by the LMS platform."""
         return "{proto}://{host}{path}".format(
-            proto=self.request.protocol,
+            proto=get_client_protocol(self),
             host=self.request.host,
             path=self.authenticator.callback_url(self.hub.server.base_url),
         )


### PR DESCRIPTION
If JupyterHub is behind a reverse proxy, protocol used in redirect URI may be wrong. Typically, user agent und proxy communicate via HTTPS, whereas proxy and hub communicate via HTTP. Up to now HTTP will make it into the redirect URI although the redirect URI will be visited by the user agent. Thus, LTI platform will complain about incorrect redirect URI.

This PR fixes the problem. Similar situations occur in other handlers and work correctly, see [`handlers.py`, line 66](https://github.com/jupyterhub/ltiauthenticator/blob/56e52570e381abed7c81fa4e1ad62e904cf0e096/ltiauthenticator/lti13/handlers.py#L66) for instance.

I tested the proposed modification on my setup (HTTPS, reverse proxy , Moodle as LTI platform), but do not have a complete dev environment in this setup . Thus, I did not run automatic tests.

Someone having deeper insight into the ltiauthenticator code should carefully check the proposed modification @martinclaus ?

Many thanks and best regards,

Jens